### PR TITLE
Fix(data): Ensure quote category is derived from structure

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -519,7 +519,7 @@ const VibeMe = {
                 .map(q => ({
                     text: String(q.text ?? q.quote ?? '').trim(),
                     author: String(q.author ?? 'Unknown').trim(),
-                    category: String(q.category ?? defaultCategory ?? 'default').trim()
+                    category: String(defaultCategory ?? q.category ?? 'default').trim()
                 }))
                 .filter(q => q.text.length > 0);
         }


### PR DESCRIPTION
The `normalizeQuotes` function was incorrectly prioritizing an inline `category` property on a quote object over the category defined by the structure of the `quotes.json` file.

This could lead to quotes being miscategorized if the data contains unexpected properties.

The fix adjusts the nullish coalescing operator's order to ensure the category from the file's structure (`defaultCategory`) is always given precedence. This makes the data parsing more robust and predictable.