### PR TITLE
feat: Improve styling of AM/PM badge

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2307,11 +2307,11 @@ button:disabled {
   /* inline, sits to the right of Seconds */
   position: static;
   align-self: center;
-  margin-left: 8px;
+  margin-left: 4px;
 
-  padding: 6px 10px;
+  padding: 8px 12px;
   border-radius: 9999px;
-  font: 700 12px/1 var(--heading-font, ui-sans-serif, system-ui);
+  font: 800 18px/1 var(--heading-font, ui-sans-serif, system-ui);
   letter-spacing: .5px;
 
   /* use your flip-clock tokens so it matches every theme */
@@ -2341,9 +2341,9 @@ button:disabled {
 
 @media (max-width: 520px){
   .fc-meridiem-badge{
-    margin-left: 6px;
-    padding: 4px 8px;
-    font-size: 11px;
+    margin-left: 4px;
+    padding: 6px 10px;
+    font-size: 15px;
     border-radius: 9px;
   }
 }
@@ -2430,7 +2430,7 @@ button:disabled {
 /* Container - .fc-clock */
 .fc-clock {
   display: flex;
-  align-items: end;
+  align-items: center;
   justify-content: center;
   gap: 0.75rem;
   white-space: nowrap;


### PR DESCRIPTION
This commit improves the UI of the AM/PM badge in the flip clock to better match the overall aesthetics of the application.

Based on user feedback, the following changes were made:
- Increased the font size and weight of the badge to be proportional to the clock digits.
- Adjusted padding for better visual balance.
- Reduced the margin to bring the badge closer to the time.
- Corrected the vertical alignment by changing the parent container's flexbox alignment to center the badge with the clock digits.

These changes have been visually verified using a Playwright script to ensure they meet the user's requirements.