### PR TITLE
fix: avoid unsanitized innerHTML in toast

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,6 @@
 // js/main.js - VibeMe Enhanced JavaScript (No Modules)
+// Guideline: Avoid assigning untrusted content to `innerHTML`.
+// Prefer using `textContent`/`appendChild` or sanitize inputs before insertion.
 
 // ===== Unified Quotes Loader (single source: data/quotes.json; optional inline fallback for file://) =====
 (function(){
@@ -3552,6 +3554,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const wrap = document.createElement('div');
         wrap.id = 'matrix-preset-wrapper';
         wrap.className = 'space-y-2 mt-3';
+        // Static options; safe to use innerHTML here.
         wrap.innerHTML = `
             <label for="matrix-preset" class="text-xs text-gray-300">Matrix Preset</label>
             <select id="matrix-preset" class="w-full text-black p-1 rounded text-xs">
@@ -3708,21 +3711,38 @@ document.addEventListener('DOMContentLoaded', () => {
   function showToast(message, type='info', ms=1600){
     const root = document.getElementById('toast-root');
     if (!root) return;
-    
+
     const toast = document.createElement('div');
     toast.className = `toast toast-${type}`;
-    toast.innerHTML = `
-      <div class="flex items-center justify-between space-x-3">
-        <div class="flex items-center space-x-2">
-          <i class="text-sm ${type === 'success' ? 'fas fa-check-circle' : 
-                               type === 'error' ? 'fas fa-exclamation-circle' : 
-                               'fas fa-info-circle'}"></i>
-          <span class="text-sm">${message}</span>
-        </div>
-        <button class="text-white/60 hover:text-white/80 text-xs" onclick="this.parentNode.parentNode.remove()">✕</button>
-      </div>
-    `;
-    
+
+    // Build DOM nodes manually to avoid injecting unsanitized HTML.
+    const container = document.createElement('div');
+    container.className = 'flex items-center justify-between space-x-3';
+
+    const left = document.createElement('div');
+    left.className = 'flex items-center space-x-2';
+
+    const icon = document.createElement('i');
+    icon.className = `text-sm ${type === 'success' ? 'fas fa-check-circle' :
+                                 type === 'error' ? 'fas fa-exclamation-circle' :
+                                 'fas fa-info-circle'}`;
+
+    const span = document.createElement('span');
+    span.className = 'text-sm';
+    span.textContent = message;
+
+    left.appendChild(icon);
+    left.appendChild(span);
+
+    const btn = document.createElement('button');
+    btn.className = 'text-white/60 hover:text-white/80 text-xs';
+    btn.textContent = '✕';
+    btn.onclick = function(){ this.parentNode.parentNode.remove(); };
+
+    container.appendChild(left);
+    container.appendChild(btn);
+    toast.appendChild(container);
+
     root.appendChild(toast);
     
     // Auto-dismiss
@@ -3864,6 +3884,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function FcPiece(label, value){
     var el = document.createElement('span');
     el.className = 'fc-piece';
+    // `label` is internal (Hours, Minutes); sanitize if ever using external data.
     el.innerHTML =
       '<b class="fc-card">' +
         '<b class="fc-top"></b>' +
@@ -4085,6 +4106,7 @@ document.addEventListener('DOMContentLoaded', () => {
     items.forEach((q, idx) => {
       const row = document.createElement('div');
       row.className = 'fav-item';
+      // escapeHTML protects against injection from saved quotes.
       row.innerHTML = `
         <div class="fav-text-wrap">
           <div class="fav-quote">"${escapeHTML(q.text)}"</div>


### PR DESCRIPTION
## Summary
- document guideline discouraging unsanitized innerHTML
- build toast DOM elements with textContent instead of innerHTML
- comment static innerHTML blocks to clarify safety

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b97bccdd4c832b9db54480ccf05047