### PR TITLE
Disable rail transitions for reduced-motion

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2262,6 +2262,16 @@ button:disabled {
 #favorites-panel[data-state="open"]   { max-height: 80vh; opacity: 1; pointer-events: auto; transform: translateY(0); }
 #favorites-panel[data-state="closed"] { max-height: 0;    opacity: 0; pointer-events: none; transform: translateY(8px); }
 
+@media (prefers-reduced-motion: reduce) {
+  .favorites-panel,
+  #favorites-panel[data-state="open"],
+  #favorites-panel[data-state="closed"],
+  #favorites-panel.open {
+    transition: none !important;
+    transform: none !important;
+  }
+}
+
 .favorites-header { background: linear-gradient(180deg, rgba(255,255,255,0.06), rgba(255,255,255,0.03)); border-bottom: 1px solid rgba(255,255,255,0.10); }
 .favorites-icon-btn { padding: 5px 8px; font-size: 12px; border-radius: 8px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.08); color: var(--text-color-secondary); }
 .favorites-icon-btn:hover { background: rgba(255,255,255,0.12); }


### PR DESCRIPTION
## Summary
- Respect motion preferences on the favorites rail by disabling its transitions and transforms when `prefers-reduced-motion: reduce` is set.

## Testing
- `npm test` *(fails: Missing script "test")*
- `node - <<'NODE' ... NODE` *(jsdom did not apply `prefers-reduced-motion`, so manual verification recommended)*

------
https://chatgpt.com/codex/tasks/task_e_68b97bd59e30832b8aaee0b6f82e53e0