### PR TITLE
feat: make application layout mobile-friendly

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -997,7 +997,6 @@ button:disabled {
     }
     
     #settings-panel {
-        width: 250px;
         right: 1rem;
     }
 }
@@ -1018,7 +1017,7 @@ button:disabled {
     }
     
     .generate-btn span {
-        font-size: 0.6rem;
+        font-size: 0.7rem;
     }
     
     .social-bubble {
@@ -1031,7 +1030,6 @@ button:disabled {
     }
     
     #settings-panel {
-        width: 200px;
         padding: var(--spacing-md);
     }
     

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
     </script>
 </head>
 
-<body class="min-h-screen flex items-center justify-center p-0 gradient-bg">
+<body class="min-h-screen gradient-bg sm:flex sm:items-center sm:justify-center p-0">
     <!-- Skip link for accessibility -->
     <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-blue-600 text-white px-4 py-2 rounded z-50">
         Skip to main content
@@ -109,12 +109,12 @@
 
     <!-- Settings panel -->
     <div id="settings-panel" 
-         class="hidden fixed top-16 right-4 z-[10000] bg-black/70 backdrop-blur-md p-4 rounded-lg shadow-xl text-white space-y-3 w-60 max-h-[80vh] overflow-y-auto pr-1"
+         class="hidden fixed top-16 right-4 left-4 sm:left-auto sm:w-60 z-[10000] bg-black/70 backdrop-blur-md p-4 rounded-lg shadow-xl text-white space-y-3 max-h-[80vh] overflow-y-auto pr-1"
          role="dialog"
          aria-labelledby="settings-title"
          aria-hidden="true">
         
-        <h2 id="settings-title" class="text-lg font-semibold mb-3">Settings</h2>
+        <h2 id="settings-title" class="text-base sm:text-lg font-semibold mb-3">Settings</h2>
         
         <div class="space-y-3">
             <label for="effects-toggle-checkbox" class="flex items-center cursor-pointer text-sm">
@@ -554,7 +554,7 @@
     </div>
 
     <!-- Main content -->
-    <main id="main-content" class="container mx-auto max-w-4xl relative z-10 pt-8">
+    <main id="main-content" class="w-full relative z-10 p-4 sm:p-6 lg:p-8">
         <!-- App Title Bar (centered, outside the quote box) -->
         <div id="app-title-bar" class="app-title-bar" role="banner" aria-label="Application Title">
           <h1 class="vb-logo heading-font" data-title="VibeMe">VibeMe</h1>
@@ -578,12 +578,12 @@
                              aria-live="polite" aria-atomic="true">
                         <blockquote>
                             <p id="quote-text"
-                               class="quote-text-font text-2xl md:text-3xl mb-4 leading-relaxed dynamic-text-main quote-text-animate">
+                               class="quote-text-font text-xl sm:text-2xl md:text-3xl mb-4 leading-relaxed dynamic-text-main quote-text-animate">
                                The only way to do great work is to love what you do.
                             </p>
                             <footer>
                                 <cite id="quote-author"
-                                      class="text-lg italic dynamic-text-secondary author-font author-animate">
+                                      class="text-base sm:text-lg italic dynamic-text-secondary author-font author-animate">
                                       — Steve Jobs
                                 </cite>
                             </footer>


### PR DESCRIPTION
The application was not responsive on mobile devices, leading to a "scrunched up" and disproportionate layout. This was caused by fixed widths, non-responsive typography, and a layout that was centered on all screen sizes.

This commit introduces several changes to make the application mobile-friendly:

- **Responsive Layout:** The main layout is now mobile-first. On small screens, the content aligns to the top for a natural scrolling experience. On larger screens, the content is centered.
- **Responsive Typography:** Font sizes for the quote, author, and other UI elements now adapt to different screen sizes, improving readability on mobile.
- **Responsive Panels:** The settings panel is now full-width on mobile devices, making it easier to use.

These changes were verified by taking screenshots at different viewport sizes to ensure the application looks and functions correctly on both mobile and desktop.