### PR TITLE
fix: correct date position on desktop

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,10 +1,11 @@
 /* =============================
-   Date pill (re-positioned)
+   Date pill (default desktop)
    ============================= */
 .fc-date {
-  /* Now lives inside the flex column of the title bar */
-  position: static;
-  z-index: 1;
+  position: fixed;
+  top: 1rem;
+  left: 8rem;
+  z-index: 10001;
   padding: 0.4rem 0.6rem;
   border-radius: 10px;
   background: rgba(0, 0, 0, 0.35);
@@ -15,7 +16,6 @@
   letter-spacing: 0.02em;
   line-height: 1;
   box-shadow: 0 8px 24px rgba(0,0,0,.18);
-  margin-top: 0.5rem; /* Space below clock */
 }
 
 /* Numeric stability */
@@ -31,11 +31,6 @@ html:not([data-theme="dark"]) .fc-date { background: rgba(0,0,0,0.45); }
 
 /* Small screens */
 @media (max-width: 480px){
-  .fc-date {
-    font-size: 0.8rem;
-    padding: 0.3rem 0.5rem;
-    margin-top: 0.75rem;
-  }
 }
 /* css/style.css - VibeMe Enhanced Styles */
 
@@ -1691,6 +1686,13 @@ button:disabled {
     html, body {
         height: auto !important;
         overflow-y: auto !important;
+    }
+
+    .fc-date {
+        position: static;
+        margin-top: 0.75rem;
+        font-size: 0.8rem;
+        padding: 0.3rem 0.5rem;
     }
 }
 


### PR DESCRIPTION
This commit resolves a regression where a change intended for mobile layouts incorrectly affected the desktop view. The date element, which was moved to be centered below the clock on mobile, was also appearing in that position on desktop.

The fix involves restoring the original `position: fixed` styles for the date element by default, ensuring it appears in the top-left corner on desktop screens. A new media query is then used to apply the mobile-specific `position: static` style only on screens smaller than 640px.

This ensures the date is positioned correctly on both desktop and mobile, preserving the original desktop design while maintaining the improved mobile layout.