### PR TITLE
feat: restyle sidebar with floating glass design

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -103,11 +103,11 @@ html:not([data-theme="dark"]) .fc-date { background: rgba(0,0,0,0.45); }
     --rail-width: 120px;
     --rail-width-collapsed: 56px;
     --rail-edge-hotzone: 28px;
-    --rail-bg: rgba(25, 17, 44, 0.85);
+    --rail-bg: rgba(30, 16, 60, 0.85);
     --rail-stroke: rgba(255, 255, 255, 0.1);
     --rail-blur: 16px;
-    --rail-aura-inner: rgba(255,255,255,0.35);
-    --rail-aura-outer: rgba(255,255,255,0.15);
+    --rail-aura-inner: rgba(124, 58, 237, 0.35);
+    --rail-aura-outer: rgba(124, 58, 237, 0.15);
     --rail-hide-delay: 18000ms;
     --rail-animation-duration: var(--transition-medium);
 }
@@ -2612,11 +2612,10 @@ button:disabled {
 
 #left-rail {
   position: fixed;
-  top: 1rem;
+  top: 4rem;
   left: 1rem;
-  bottom: 1rem;
   width: var(--rail-width);
-  height: calc(100vh - 2rem);
+  max-height: calc(100vh - 8rem);
   transform: translateX(-140%);
   opacity: 0;
   transition: transform var(--rail-animation-duration), opacity var(--rail-animation-duration);
@@ -2646,6 +2645,20 @@ button:disabled {
     radial-gradient(closest-side, var(--rail-aura-inner), transparent),
     radial-gradient(closest-side, var(--rail-aura-outer), transparent);
   filter: blur(12px);
+  z-index: -2;
+}
+
+#left-rail::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(at top left, rgba(255,255,255,0.08), transparent 60%),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4'/></filter><rect width='200' height='200' filter='url(%23n)'/></svg>");
+  background-size: cover, 150px 150px;
+  mix-blend-mode: overlay;
+  opacity: 0.15;
   z-index: -1;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -100,11 +100,11 @@ html:not([data-theme="dark"]) .fc-date { background: rgba(0,0,0,0.45); }
     --card-radius: var(--radius-lg);
 
     /* Left rail tokens */
-    --rail-width: 160px;
+    --rail-width: 120px;
     --rail-width-collapsed: 56px;
     --rail-edge-hotzone: 28px;
-    --rail-bg: rgba(255, 255, 255, 0.25);
-    --rail-stroke: rgba(255, 255, 255, 0.35);
+    --rail-bg: rgba(25, 17, 44, 0.85);
+    --rail-stroke: rgba(255, 255, 255, 0.1);
     --rail-blur: 16px;
     --rail-aura-inner: rgba(255,255,255,0.35);
     --rail-aura-outer: rgba(255,255,255,0.15);
@@ -2612,10 +2612,11 @@ button:disabled {
 
 #left-rail {
   position: fixed;
-  top: 0;
-  left: 0;
+  top: 1rem;
+  left: 1rem;
+  bottom: 1rem;
   width: var(--rail-width);
-  height: 100vh;
+  height: calc(100vh - 2rem);
   transform: translateX(-140%);
   opacity: 0;
   transition: transform var(--rail-animation-duration), opacity var(--rail-animation-duration);
@@ -2623,11 +2624,12 @@ button:disabled {
   -webkit-backdrop-filter: blur(var(--rail-blur)) saturate(160%);
   background: var(--rail-bg);
   border: 1px solid var(--rail-stroke);
-  border-radius: var(--radius-lg);
+  border-radius: 1rem;
   z-index: var(--z-popover);
-  color: #fff;
+  color: rgba(255, 255, 255, 0.9);
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 #left-rail.show {
@@ -2692,10 +2694,30 @@ button:disabled {
   border-radius: var(--radius-md);
   cursor: pointer;
   text-align: left;
+  transition: background 0.2s;
 }
 
-#left-rail .rail-btn:hover {
+#left-rail .rail-btn:not(.active):hover {
   background: rgba(255, 255, 255, 0.1);
+}
+
+#left-rail .rail-btn.active {
+  background: #3b82f6;
+  color: #fff;
+  border-radius: 9999px;
+}
+
+#left-rail .rail-btn i {
+  font-size: 1rem;
+  width: 1rem;
+  text-align: center;
+}
+
+#left-rail .rail-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.1);
+  margin: 4px 0;
+  border: 0;
 }
 
 #left-rail[data-size="collapsed"] .rail-btn {

--- a/css/style.css
+++ b/css/style.css
@@ -41,6 +41,9 @@ html:not([data-theme="dark"]) .fc-date { background: rgba(0,0,0,0.45); }
     --color1: #aaaaaa;
     --color2: #bbbbbb;
     --color3: #cccccc;
+    --color1-rgb: 170, 170, 170;
+    --color2-rgb: 187, 187, 187;
+    --color3-rgb: 204, 204, 204;
     --container-bg-color: rgba(255, 255, 255, 0.95);
     --inner-box-color: rgba(255, 255, 255, 0.85);
     --text-color-main: #374151;
@@ -103,7 +106,12 @@ html:not([data-theme="dark"]) .fc-date { background: rgba(0,0,0,0.45); }
     --rail-width: 120px;
     --rail-width-collapsed: 56px;
     --rail-edge-hotzone: 28px;
-    --rail-bg: rgba(30, 16, 60, 0.8);
+    --rail-bg: linear-gradient(
+      135deg,
+      rgba(var(--color1-rgb), 0.5),
+      rgba(var(--color2-rgb), 0.6),
+      rgba(var(--color3-rgb), 0.5)
+    );
     --rail-stroke: rgba(255, 255, 255, 0.1);
     --rail-blur: 16px;
     --rail-aura-inner: rgba(124, 58, 237, 0.35);

--- a/css/style.css
+++ b/css/style.css
@@ -103,7 +103,7 @@ html:not([data-theme="dark"]) .fc-date { background: rgba(0,0,0,0.45); }
     --rail-width: 120px;
     --rail-width-collapsed: 56px;
     --rail-edge-hotzone: 28px;
-    --rail-bg: rgba(30, 16, 60, 0.85);
+    --rail-bg: rgba(30, 16, 60, 0.8);
     --rail-stroke: rgba(255, 255, 255, 0.1);
     --rail-blur: 16px;
     --rail-aura-inner: rgba(124, 58, 237, 0.35);
@@ -2612,11 +2612,10 @@ button:disabled {
 
 #left-rail {
   position: fixed;
-  top: 4rem;
+  top: 50%;
   left: 1rem;
   width: var(--rail-width);
-  max-height: calc(100vh - 8rem);
-  transform: translateX(-140%);
+  transform: translate(-140%, -50%);
   opacity: 0;
   transition: transform var(--rail-animation-duration), opacity var(--rail-animation-duration);
   backdrop-filter: blur(var(--rail-blur)) saturate(160%);
@@ -2632,7 +2631,7 @@ button:disabled {
 }
 
 #left-rail.show {
-  transform: translateX(0);
+  transform: translate(0, -50%);
   opacity: 1;
 }
 

--- a/index.html
+++ b/index.html
@@ -72,18 +72,19 @@
     <div id="edge-hotzone" aria-hidden="true"></div>
     <nav id="left-rail" role="navigation" aria-label="VibeMe quick actions" data-state="hidden" data-size="expanded">
       <header class="rail-header">
-        <button class="rail-pin" aria-pressed="false" title="Pin panel">📌</button>
-        <button class="rail-collapse" aria-expanded="true" title="Collapse">«</button>
+        <button class="rail-pin" aria-pressed="false" title="Pin panel"><i class="fas fa-thumbtack" aria-hidden="true"></i></button>
+        <button class="rail-collapse" aria-expanded="true" title="Collapse"><i class="fas fa-chevron-left" aria-hidden="true"></i></button>
       </header>
       <ul class="rail-items">
-        <li><button class="rail-btn" data-action="new"       title="New Vibe"      aria-label="New Vibe">✨ <span class="label">New Vibe</span></button></li>
-        <li><button class="rail-btn" data-action="fav"       title="Favorites"     aria-label="Favorites">⭐ <span class="label">Favorites</span></button></li>
-        <li><button class="rail-btn" data-action="bookmarks" title="Bookmarks"     aria-label="Bookmarks">🔖 <span class="label">Bookmarks</span></button></li>
-        <li><button class="rail-btn" data-action="share"     title="Share"         aria-label="Share">📤 <span class="label">Share</span></button></li>
-        <li><button class="rail-btn" data-action="tts"       title="Read Aloud"    aria-label="Read Aloud">🔊 <span class="label">Read Aloud</span></button></li>
-        <li><button class="rail-btn" data-action="theme"     title="Theme & Color" aria-label="Theme and Color">🎨 <span class="label">Theme</span></button></li>
-        <li><button class="rail-btn" data-action="settings"  title="Settings"      aria-label="Settings">⚙️ <span class="label">Settings</span></button></li>
-        <li><button class="rail-btn" data-action="about"     title="About VibeMe"  aria-label="About VibeMe">ℹ️ <span class="label">About</span></button></li>
+        <li><button class="rail-btn" data-action="new"       title="New Vibe"      aria-label="New Vibe"><i class="fas fa-wand-magic-sparkles" aria-hidden="true"></i><span class="label">New Vibe</span></button></li>
+        <li><button class="rail-btn" data-action="fav"       title="Favorites"     aria-label="Favorites"><i class="fas fa-star" aria-hidden="true"></i><span class="label">Favorites</span></button></li>
+        <li><button class="rail-btn" data-action="bookmarks" title="Bookmarks"     aria-label="Bookmarks"><i class="fas fa-bookmark" aria-hidden="true"></i><span class="label">Bookmarks</span></button></li>
+        <li><button class="rail-btn" data-action="share"     title="Share"         aria-label="Share"><i class="fas fa-share-nodes" aria-hidden="true"></i><span class="label">Share</span></button></li>
+        <li><button class="rail-btn" data-action="tts"       title="Read Aloud"    aria-label="Read Aloud"><i class="fas fa-volume-high" aria-hidden="true"></i><span class="label">Read Aloud</span></button></li>
+        <li><button class="rail-btn" data-action="theme"     title="Theme & Color" aria-label="Theme and Color"><i class="fas fa-palette" aria-hidden="true"></i><span class="label">Theme</span></button></li>
+        <li class="rail-divider" role="separator"></li>
+        <li><button class="rail-btn" data-action="settings"  title="Settings"      aria-label="Settings"><i class="fas fa-gear" aria-hidden="true"></i><span class="label">Settings</span></button></li>
+        <li><button class="rail-btn" data-action="about"     title="About VibeMe"  aria-label="About VibeMe"><i class="fas fa-circle-info" aria-hidden="true"></i><span class="label">About</span></button></li>
       </ul>
     </nav>
     <!-- Skip link for accessibility -->

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
         <li><button class="rail-btn" data-action="theme"     title="Theme & Color" aria-label="Theme and Color"><i class="fas fa-palette" aria-hidden="true"></i><span class="label">Theme</span></button></li>
         <li class="rail-divider" role="separator"></li>
         <li><button class="rail-btn" data-action="settings"  title="Settings"      aria-label="Settings"><i class="fas fa-gear" aria-hidden="true"></i><span class="label">Settings</span></button></li>
-        <li><button class="rail-btn" data-action="about"     title="About VibeMe"  aria-label="About VibeMe"><i class="fas fa-circle-info" aria-hidden="true"></i><span class="label">About</span></button></li>
+        <li><a class="rail-btn" href="about.html" data-action="about"     title="About VibeMe"  aria-label="About VibeMe"><i class="fas fa-circle-info" aria-hidden="true"></i><span class="label">About</span></a></li>
       </ul>
     </nav>
     <!-- Skip link for accessibility -->

--- a/js/main.js
+++ b/js/main.js
@@ -4611,6 +4611,11 @@ document.addEventListener('DOMContentLoaded', () => {
   rail.dataset.size = size;
   const pinBtn = rail.querySelector('.rail-pin');
   const collapseBtn = rail.querySelector('.rail-collapse');
+  const defaultBtn = rail.querySelector('.rail-btn');
+  if (defaultBtn) {
+    defaultBtn.classList.add('active');
+    defaultBtn.setAttribute('aria-current', 'page');
+  }
   if (pinned) {
     rail.classList.add('show');
     rail.dataset.state = 'visible';
@@ -4676,6 +4681,12 @@ document.addEventListener('DOMContentLoaded', () => {
   addEvent(rail, 'click', (e) => {
     const btn = e.target.closest('.rail-btn');
     if (!btn) return;
+    rail.querySelectorAll('.rail-btn').forEach(b => {
+      const active = b === btn;
+      b.classList.toggle('active', active);
+      if (active) b.setAttribute('aria-current', 'page');
+      else b.removeAttribute('aria-current');
+    });
     const action = btn.dataset.action;
     if (navigator.vibrate) navigator.vibrate(10);
     document.dispatchEvent(new CustomEvent('rail:action', {detail:{action}}));

--- a/js/main.js
+++ b/js/main.js
@@ -1189,6 +1189,12 @@ const VibeMe = {
         root.style.setProperty('--color1', theme.color1);
         root.style.setProperty('--color2', theme.color2);
         root.style.setProperty('--color3', theme.color3);
+        const c1 = this.hexToRgb(theme.color1);
+        const c2 = this.hexToRgb(theme.color2);
+        const c3 = this.hexToRgb(theme.color3);
+        root.style.setProperty('--color1-rgb', `${c1.r}, ${c1.g}, ${c1.b}`);
+        root.style.setProperty('--color2-rgb', `${c2.r}, ${c2.g}, ${c2.b}`);
+        root.style.setProperty('--color3-rgb', `${c3.r}, ${c3.g}, ${c3.b}`);
         
         // Calculate optimal text colors using WCAG standards
         const backgroundColor = theme.color1; // Primary background color
@@ -3283,6 +3289,13 @@ function applyPalette({ color1, color2, color3, accent }){
   root.style.setProperty('--color1', color1);
   root.style.setProperty('--color2', color2);
   root.style.setProperty('--color3', color3);
+  const toRgb = hex => {
+    const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    return m ? `${parseInt(m[1],16)}, ${parseInt(m[2],16)}, ${parseInt(m[3],16)}` : '0,0,0';
+  };
+  root.style.setProperty('--color1-rgb', toRgb(color1));
+  root.style.setProperty('--color2-rgb', toRgb(color2));
+  root.style.setProperty('--color3-rgb', toRgb(color3));
   if (accent) root.style.setProperty('--social-icon-bg', accent);
 
   const avg = (__vibeme_hexLuma(color1) + __vibeme_hexLuma(color2) + __vibeme_hexLuma(color3)) / 3;


### PR DESCRIPTION
## Summary
- shrink sidebar into a floating glass card with rounded corners and dark translucent backdrop
- swap emoji icons for solid Font Awesome set and insert a divider before settings
- add active pill highlight and hover transitions for rail items

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcce6b9930832ba407a266237d189a