### PR TITLE
feat: close sidebar on outside click

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -4719,7 +4719,13 @@ document.addEventListener('DOMContentLoaded', () => {
     if (x < parseInt(getComputedStyle(hotzone).width)) {
       show();
     } else if (!rail.contains(e.target) && !pinned) {
-      scheduleHide();
+      hide();
+    }
+  });
+
+  addEvent(document, 'mousedown', (e) => {
+    if (!rail.contains(e.target) && !hotzone.contains(e.target) && !pinned) {
+      hide();
     }
   });
 


### PR DESCRIPTION
## Summary
- close sidebar immediately when clicking outside the rail
- hide sidebar instantly on touch outside

## Testing
- `node --check js/main.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bce41110c0832bafd2b33ae7305796