### PR TITLE
Add quick actions rail sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,25 @@
     </script>
 </head>
 
-<body class="min-h-screen gradient-bg sm:flex sm:items-center sm:justify-center p-0">
+<body class="min-h-screen flex items-center justify-center p-0 gradient-bg">
+    <div id="edge-hotzone" aria-hidden="true"></div>
+    <nav id="left-rail" role="navigation" aria-label="VibeMe quick actions" data-state="hidden" data-size="expanded">
+      <header class="rail-header">
+        <button class="rail-pin" aria-pressed="false" title="Pin panel"><i class="fas fa-thumbtack" aria-hidden="true"></i></button>
+        <button class="rail-collapse" aria-expanded="true" title="Collapse"><i class="fas fa-chevron-left" aria-hidden="true"></i></button>
+      </header>
+      <ul class="rail-items">
+        <li><button class="rail-btn" data-action="new"       title="New Vibe"      aria-label="New Vibe"><i class="fas fa-wand-magic-sparkles" aria-hidden="true"></i><span class="label">New Vibe</span></button></li>
+        <li><button class="rail-btn" data-action="fav"       title="Favorites"     aria-label="Favorites"><i class="fas fa-star" aria-hidden="true"></i><span class="label">Favorites</span></button></li>
+        <li><button class="rail-btn" data-action="bookmarks" title="Bookmarks"     aria-label="Bookmarks"><i class="fas fa-bookmark" aria-hidden="true"></i><span class="label">Bookmarks</span></button></li>
+        <li><button class="rail-btn" data-action="share"     title="Share"         aria-label="Share"><i class="fas fa-share-nodes" aria-hidden="true"></i><span class="label">Share</span></button></li>
+        <li><button class="rail-btn" data-action="tts"       title="Read Aloud"    aria-label="Read Aloud"><i class="fas fa-volume-high" aria-hidden="true"></i><span class="label">Read Aloud</span></button></li>
+        <li><button class="rail-btn" data-action="theme"     title="Theme & Color" aria-label="Theme and Color"><i class="fas fa-palette" aria-hidden="true"></i><span class="label">Theme</span></button></li>
+        <li class="rail-divider" role="separator"></li>
+        <li><button class="rail-btn" data-action="settings"  title="Settings"      aria-label="Settings"><i class="fas fa-gear" aria-hidden="true"></i><span class="label">Settings</span></button></li>
+        <li><a class="rail-btn" href="about.html" data-action="about"     title="About VibeMe"  aria-label="About VibeMe"><i class="fas fa-circle-info" aria-hidden="true"></i><span class="label">About</span></a></li>
+      </ul>
+    </nav>
     <!-- Skip link for accessibility -->
     <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-blue-600 text-white px-4 py-2 rounded z-50">
         Skip to main content


### PR DESCRIPTION
## Summary
- insert hidden quick-actions left rail near top of body
- adjust body classes for consistent layout

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c15f67497c832ba6d3534356304d63