### PR TITLE
feat: add left rail sidebar styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -113,6 +113,23 @@ html:not([data-theme="dark"]) .fc-date { background: rgba(0,0,0,0.45); }
     --matrix-opacity-token: 0.8;
     --container-blur: 20px;
     --card-radius: var(--radius-lg);
+
+    /* Left rail tokens */
+    --rail-width: 120px;
+    --rail-width-collapsed: 56px;
+    --rail-edge-hotzone: 28px;
+    --rail-bg: linear-gradient(
+      135deg,
+      rgba(var(--color1-rgb), 0.5),
+      rgba(var(--color2-rgb), 0.6),
+      rgba(var(--color3-rgb), 0.5)
+    );
+    --rail-stroke: rgba(255, 255, 255, 0.1);
+    --rail-blur: 16px;
+    --rail-aura-inner: rgba(124, 58, 237, 0.35);
+    --rail-aura-outer: rgba(124, 58, 237, 0.15);
+    --rail-hide-delay: 18000ms;
+    --rail-animation-duration: var(--transition-medium);
 }
 
 /* ===== RESET & BASE STYLES ===== */
@@ -2787,4 +2804,139 @@ button:disabled {
     color: #a0a0a0;
     text-align: center;
     padding: 2rem;
+}
+/* ===== Left Rail ===== */
+#edge-hotzone {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: var(--rail-edge-hotzone);
+  height: 100vh;
+  z-index: var(--z-popover);
+}
+
+#left-rail {
+  position: fixed;
+  top: 50%;
+  left: 1rem;
+  width: var(--rail-width);
+  transform: translate(-140%, -50%);
+  opacity: 0;
+  transition: transform var(--rail-animation-duration), opacity var(--rail-animation-duration);
+  backdrop-filter: blur(var(--rail-blur)) saturate(160%);
+  -webkit-backdrop-filter: blur(var(--rail-blur)) saturate(160%);
+  background: var(--rail-bg);
+  border: 1px solid var(--rail-stroke);
+  border-radius: 1rem;
+  z-index: var(--z-popover);
+  color: rgba(255, 255, 255, 0.9);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+#left-rail.show {
+  transform: translate(0, -50%);
+  opacity: 1;
+}
+
+#left-rail::before {
+  content: "";
+  position: absolute;
+  inset: -12px;
+  border-radius: inherit;
+  background:
+    radial-gradient(closest-side, var(--rail-aura-inner), transparent),
+    radial-gradient(closest-side, var(--rail-aura-outer), transparent);
+  filter: blur(12px);
+  z-index: -2;
+}
+
+#left-rail::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(at top left, rgba(255,255,255,0.08), transparent 60%),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4'/></filter><rect width='200' height='200' filter='url(%23n)'/></svg>");
+  background-size: cover, 150px 150px;
+  mix-blend-mode: overlay;
+  opacity: 0.15;
+  z-index: -1;
+}
+
+#left-rail[data-size="collapsed"] {
+  width: var(--rail-width-collapsed);
+}
+
+#left-rail[data-size="collapsed"] .label {
+  display: none;
+}
+
+#left-rail .rail-header {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  padding: 4px;
+}
+
+#left-rail .rail-pin,
+#left-rail .rail-collapse {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+#left-rail .rail-items {
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+#left-rail .rail-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s;
+}
+
+#left-rail .rail-btn:not(.active):hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+#left-rail .rail-btn.active {
+  background: #3b82f6;
+  color: #fff;
+  border-radius: 9999px;
+}
+
+#left-rail .rail-btn i {
+  font-size: 1rem;
+  width: 1rem;
+  text-align: center;
+}
+
+#left-rail .rail-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.1);
+  margin: 4px 0;
+  border: 0;
+}
+
+#left-rail[data-size="collapsed"] .rail-btn {
+  justify-content: center;
 }


### PR DESCRIPTION
## Summary
- style left rail sidebar with glassy background, animations, and layout
- add hotzone, collapsed state, and interactive button styles
- define CSS custom properties for rail sizing, aesthetics, and animations

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c15ff870cc832b87b502f5351ac21a