### PR TITLE
Isolate About button in sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
 <body class="min-h-screen flex items-center justify-center p-0 gradient-bg">
     <div id="edge-hotzone" aria-hidden="true"></div>
     <nav id="left-rail" role="navigation" aria-label="VibeMe quick actions" data-state="hidden" data-size="expanded">
+      <!--
       <header class="rail-header">
         <button class="rail-pin" aria-pressed="false" title="Pin panel"><i class="fas fa-thumbtack" aria-hidden="true"></i></button>
         <button class="rail-collapse" aria-expanded="true" title="Collapse"><i class="fas fa-chevron-left" aria-hidden="true"></i></button>
@@ -84,6 +85,10 @@
         <li><button class="rail-btn" data-action="theme"     title="Theme & Color" aria-label="Theme and Color"><i class="fas fa-palette" aria-hidden="true"></i><span class="label">Theme</span></button></li>
         <li class="rail-divider" role="separator"></li>
         <li><button class="rail-btn" data-action="settings"  title="Settings"      aria-label="Settings"><i class="fas fa-gear" aria-hidden="true"></i><span class="label">Settings</span></button></li>
+        <li><a class="rail-btn" href="about.html" data-action="about"     title="About VibeMe"  aria-label="About VibeMe"><i class="fas fa-circle-info" aria-hidden="true"></i><span class="label">About</span></a></li>
+      </ul>
+      -->
+      <ul class="rail-items">
         <li><a class="rail-btn" href="about.html" data-action="about"     title="About VibeMe"  aria-label="About VibeMe"><i class="fas fa-circle-info" aria-hidden="true"></i><span class="label">About</span></a></li>
       </ul>
     </nav>


### PR DESCRIPTION
## Summary
- Comment out the sidebar header and all buttons except About for focused development.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1718aecb0832bbde67595352aaddf