### PR TITLE
feat: add simple event bus

### DIFF
--- a/src/lib/bus.ts
+++ b/src/lib/bus.ts
@@ -1,0 +1,30 @@
+export type Handler<T = any> = (payload: T) => void;
+
+export class EventBus {
+  private listeners = new Map<string, Set<Handler>>();
+
+  on<T = any>(event: string, handler: Handler<T>): void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(handler as Handler);
+  }
+
+  off<T = any>(event: string, handler: Handler<T>): void {
+    this.listeners.get(event)?.delete(handler as Handler);
+  }
+
+  emit<T = any>(event: string, payload: T): void {
+    this.listeners.get(event)?.forEach((handler) => handler(payload));
+  }
+}
+
+export const bus = new EventBus();
+
+export const EVENTS = {
+  QUOTE_GENERATED: 'QUOTE_GENERATED',
+  THEME_CHANGED: 'THEME_CHANGED',
+  FAVORITE_ADDED: 'FAVORITE_ADDED',
+  FAVORITE_REMOVED: 'FAVORITE_REMOVED',
+} as const;
+


### PR DESCRIPTION
## Summary
- add generic event bus with on/off/emit
- expose global bus and common event names

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c2b7082a38832bb9f72b3285ba547f