### PR TITLE
feat(matrix): introduce rendering engine

### DIFF
--- a/src/features/matrix/engine.ts
+++ b/src/features/matrix/engine.ts
@@ -1,0 +1,46 @@
+import { bus, EVENTS } from '../../lib/bus';
+import { store } from '../../lib/store';
+import { MatrixConfig, RenderMode } from './config';
+import { startDOM, stopDOM } from './dom';
+import { startCanvas, stopCanvas } from './canvas';
+
+let currentMode: RenderMode | null = null;
+
+function getConfig(): MatrixConfig {
+  return store.get('matrix');
+}
+
+function apply(config: MatrixConfig): void {
+  if (currentMode === RenderMode.CANVAS) {
+    stopCanvas();
+  } else if (currentMode !== null) {
+    stopDOM();
+  }
+
+  currentMode = config.renderMode;
+
+  if (currentMode === RenderMode.CANVAS) {
+    startCanvas(config);
+  } else {
+    startDOM(config);
+  }
+}
+
+export function initMatrix(): void {
+  apply(getConfig());
+  bus.on(EVENTS.THEME_CHANGED, updateMatrix);
+}
+
+export function updateMatrix(): void {
+  apply(getConfig());
+}
+
+export function teardownMatrix(): void {
+  bus.off(EVENTS.THEME_CHANGED, updateMatrix);
+  if (currentMode === RenderMode.CANVAS) {
+    stopCanvas();
+  } else if (currentMode !== null) {
+    stopDOM();
+  }
+  currentMode = null;
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,20 @@
+import { MatrixConfig, DEFAULTS } from '../features/matrix/config';
+
+interface State {
+  matrix: MatrixConfig;
+}
+
+const state: State = {
+  matrix: DEFAULTS,
+};
+
+export const store = {
+  get<K extends keyof State>(key: K): State[K] {
+    return state[key];
+  },
+  set<K extends keyof State>(key: K, value: State[K]): void {
+    state[key] = value;
+  },
+};
+
+export type Store = typeof store;


### PR DESCRIPTION
## Summary
- add matrix engine to orchestrate DOM or canvas rendering
- store matrix configuration centrally

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c2c3f38304832b9391b3da196160fd