### PR TITLE
Route matrix settings through engine

### DIFF
--- a/src/features/matrix/ui.ts
+++ b/src/features/matrix/ui.ts
@@ -1,0 +1,53 @@
+import { initMatrix, updateMatrix, teardownMatrix } from './engine';
+import { store } from '../../lib/store';
+import { RenderMode, MatrixConfig } from './config';
+
+function getConfig(): MatrixConfig {
+  return store.get('matrix');
+}
+
+function setConfig(cfg: MatrixConfig): void {
+  store.set('matrix', cfg);
+}
+
+export function bindMatrixUI(): void {
+  const toggle = document.getElementById('effects-toggle-checkbox') as HTMLInputElement | null;
+  const renderModeSel = document.getElementById('matrix-render-mode') as HTMLSelectElement | null;
+  const densityRange = document.getElementById('matrix-density') as HTMLInputElement | null;
+  const maxFpsRange = document.getElementById('canvas-max-fps') as HTMLInputElement | null;
+
+  let active = toggle?.checked ?? false;
+  if (active) {
+    initMatrix();
+  }
+
+  toggle?.addEventListener('change', () => {
+    active = toggle.checked;
+    if (active) {
+      initMatrix();
+    } else {
+      teardownMatrix();
+    }
+  });
+
+  renderModeSel?.addEventListener('change', () => {
+    const cfg = getConfig();
+    setConfig({ ...cfg, renderMode: renderModeSel.value as RenderMode });
+    if (active) updateMatrix();
+  });
+
+  densityRange?.addEventListener('input', () => {
+    const cfg = getConfig();
+    setConfig({ ...cfg, densityMultiplier: parseFloat(densityRange.value) });
+    if (active) updateMatrix();
+  });
+
+  maxFpsRange?.addEventListener('input', () => {
+    const cfg = getConfig();
+    setConfig({
+      ...cfg,
+      canvasConfig: { ...cfg.canvasConfig, maxFPS: parseInt(maxFpsRange.value, 10) }
+    });
+    if (active) updateMatrix();
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,11 @@
 import { bridgeLegacy } from './shell/legacy-bridge';
 import { bootstrap } from './shell/bootstrap';
+import { bindMatrixUI } from './features/matrix/ui';
 
 async function main(): Promise<void> {
   await bridgeLegacy();
   bootstrap();
+  bindMatrixUI();
 }
 
 void main();


### PR DESCRIPTION
## Summary
- bind matrix controls to engine methods via a new UI module
- call matrix bindings during startup

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c351ab7d5c832bb9a9813f4fef1282