### PR TITLE
Update matrix colors on init and theme changes

### DIFF
--- a/src/features/matrix/colors.ts
+++ b/src/features/matrix/colors.ts
@@ -47,7 +47,7 @@ export function applyMatrixColors(config: MatrixConfig, theme?: Theme): void {
   if (config.renderMode === RenderMode.DOM || config.renderMode === RenderMode.HYBRID) {
     const columns = document.querySelectorAll<HTMLElement>('.binary-column');
     columns.forEach((column, index) => {
-      const color = colors[index % colors.length];
+      const color = config.colors[index % config.colors.length];
       column.style.color = color;
       column.style.textShadow = `0 0 5px ${color}`;
     });

--- a/src/features/matrix/engine.ts
+++ b/src/features/matrix/engine.ts
@@ -3,8 +3,13 @@ import { store } from '../../lib/store';
 import { MatrixConfig, RenderMode } from './config';
 import { startDOM, stopDOM } from './dom';
 import { startCanvas, stopCanvas } from './canvas';
+import { applyMatrixColors } from './colors';
 
 let currentMode: RenderMode | null = null;
+
+function refreshColors(): void {
+  applyMatrixColors(getConfig());
+}
 
 function getConfig(): MatrixConfig {
   return store.get('matrix');
@@ -27,16 +32,20 @@ function apply(config: MatrixConfig): void {
 }
 
 export function initMatrix(): void {
-  apply(getConfig());
-  bus.on(EVENTS.THEME_CHANGED, updateMatrix);
+  const config = getConfig();
+  applyMatrixColors(config);
+  apply(config);
+  bus.on(EVENTS.THEME_CHANGED, refreshColors);
 }
 
 export function updateMatrix(): void {
-  apply(getConfig());
+  const config = getConfig();
+  applyMatrixColors(config);
+  apply(config);
 }
 
 export function teardownMatrix(): void {
-  bus.off(EVENTS.THEME_CHANGED, updateMatrix);
+  bus.off(EVENTS.THEME_CHANGED, refreshColors);
   if (currentMode === RenderMode.CANVAS) {
     stopCanvas();
   } else if (currentMode !== null) {


### PR DESCRIPTION
## Summary
- initialize matrix with computed theme colors
- refresh matrix colors when theme changes without rerender

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c35991af6c832b9295587cca55ce2e