### PR TITLE
Ensure matrix teardown cleans up resources

### DIFF
--- a/src/features/matrix/canvas.ts
+++ b/src/features/matrix/canvas.ts
@@ -118,5 +118,11 @@ export function stopCanvas(): void {
   state.canvas = null;
   state.ctx = null;
   state.config = null;
+  state.rafId = 0;
+  state.lastFrame = 0;
+}
+
+export function teardownCanvas(): void {
+  stopCanvas();
 }
 

--- a/src/features/matrix/dom.ts
+++ b/src/features/matrix/dom.ts
@@ -7,7 +7,7 @@ interface Column {
 
 let running = false;
 let rafId = 0;
-let cfg: MatrixConfig;
+let cfg: MatrixConfig | undefined;
 let active: Column[] = [];
 let pool: HTMLElement[] = [];
 
@@ -32,24 +32,26 @@ function interpolateColor(c1: string, c2: string, t: number): string {
 }
 
 function applyColors(el: HTMLElement): void {
-  if (!cfg.colors || cfg.colors.length === 0) return;
+  const cfgRef = cfg;
+  if (!cfgRef?.colors || cfgRef.colors.length === 0) return;
   const rect = el.getBoundingClientRect();
   const x = Math.min(1, Math.max(0, rect.left / Math.max(1, window.innerWidth)));
-  const maxIdx = cfg.colors.length - 1;
+  const maxIdx = cfgRef.colors.length - 1;
   const pos = x * maxIdx;
   const base = Math.floor(pos);
   const t = pos - base;
-  const c1 = cfg.colors[base];
-  const c2 = cfg.colors[Math.min(base + 1, maxIdx)];
+  const c1 = cfgRef.colors[base];
+  const c2 = cfgRef.colors[Math.min(base + 1, maxIdx)];
   const mixed = interpolateColor(c1, c2, t);
   el.style.color = mixed;
   el.style.textShadow = `0 0 5px ${mixed}`;
 }
 
 function generateContent(): string {
-  const chars = cfg.characters;
-  const maxLength = cfg.trailLength;
-  const fadeRate = cfg.trailFadeRate;
+  const cfgRef = cfg!;
+  const chars = cfgRef.characters;
+  const maxLength = cfgRef.trailLength;
+  const fadeRate = cfgRef.trailFadeRate;
   const length = Math.floor(Math.random() * maxLength) + Math.floor(maxLength * 0.3);
   let content = '';
   for (let i = 0; i < length; i++) {
@@ -89,7 +91,8 @@ function recycle(col: Column, now: number): void {
 
 function loop(now: number): void {
   if (!running) return;
-  const count = Math.floor((window.innerWidth / cfg.columnWidth) * cfg.densityMultiplier);
+  const cfgRef = cfg!;
+  const count = Math.floor((window.innerWidth / cfgRef.columnWidth) * cfgRef.densityMultiplier);
   if (active.length < count) {
     for (let i = active.length; i < count; i++) {
       const el = createElement();
@@ -129,5 +132,13 @@ export function stopDOM(): void {
     pool.push(col.el);
   });
   active = [];
+  rafId = 0;
+}
+
+export function teardownDOM(): void {
+  stopDOM();
+  pool.forEach((el) => el.remove());
+  pool = [];
+  cfg = undefined;
 }
 

--- a/src/features/matrix/engine.ts
+++ b/src/features/matrix/engine.ts
@@ -1,8 +1,8 @@
 import { bus, EVENTS } from '../../lib/bus';
 import { store } from '../../lib/store';
 import { MatrixConfig, RenderMode } from './config';
-import { startDOM, stopDOM } from './dom';
-import { startCanvas, stopCanvas } from './canvas';
+import { startDOM, stopDOM, teardownDOM } from './dom';
+import { startCanvas, stopCanvas, teardownCanvas } from './canvas';
 
 let currentMode: RenderMode | null = null;
 
@@ -38,9 +38,9 @@ export function updateMatrix(): void {
 export function teardownMatrix(): void {
   bus.off(EVENTS.THEME_CHANGED, updateMatrix);
   if (currentMode === RenderMode.CANVAS) {
-    stopCanvas();
+    teardownCanvas();
   } else if (currentMode !== null) {
-    stopDOM();
+    teardownDOM();
   }
   currentMode = null;
 }


### PR DESCRIPTION
## Summary
- add `teardownDOM` and `teardownCanvas` helpers to fully dispose matrix resources
- reset animation frame IDs and clear pools on DOM/canvas shutdown
- invoke teardown helpers in `teardownMatrix` to cancel loops and remove listeners

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c35994279c832bbb29f61c1924b03a