### PR TITLE
refactor: apply theme transitions globally

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -71,7 +71,7 @@ html:not([data-theme="dark"]) .fc-date { background: rgba(0,0,0,0.45); }
     --transition-fast: 0.2s ease;
     --transition-medium: 0.3s ease;
     --transition-slow: 0.5s ease;
-    --transition-theme: 1.5s ease;
+    --transition-theme: 300ms ease;
     --bounce-timing: cubic-bezier(0.68, -0.55, 0.265, 1.55);
     --elastic-timing: cubic-bezier(0.175, 0.885, 0.32, 1.275);
     --typewriter-speed: 0.05s;
@@ -137,6 +137,10 @@ html:not([data-theme="dark"]) .fc-date { background: rgba(0,0,0,0.45); }
     box-sizing: border-box;
 }
 
+* {
+    transition: color var(--transition-theme), background-color var(--transition-theme), border-color var(--transition-theme);
+}
+
 html {
     scroll-behavior: smooth;
 }
@@ -184,8 +188,11 @@ body { min-height: 100dvh; height: 100dvh; overflow: hidden !important; padding:
     *, *::before, *::after {
         animation-duration: 0.01ms !important;
         animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
         scroll-behavior: auto !important;
+    }
+
+    * {
+        transition-duration: 0.01ms !important;
     }
 }
 


### PR DESCRIPTION
## Summary
- shorten theme transition variable to 300ms
- apply color/background/border transitions universally
- override transition durations in reduced motion mode

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c35e23e34c832b8f2279eadeb98ba9