### PR TITLE
feat: wrap theme controls and drop direct VibeMe usage

### DIFF
--- a/about.html
+++ b/about.html
@@ -131,11 +131,10 @@
 
     <!-- Main JS for theme handling -->
 
-    <script>
+    <script type="module">
+        import { nextTheme } from './src/features/theme/theme.ts';
         document.addEventListener('DOMContentLoaded', () => {
-            if (window.VibeMe && typeof window.VibeMe.applyRandomTheme === 'function') {
-                window.VibeMe.applyRandomTheme();
-            }
+            nextTheme();
             const emailLink = document.getElementById('contact-email');
             if (emailLink) {
                 const email = `${emailLink.dataset.user}@${emailLink.dataset.domain}`;

--- a/src/features/theme/theme.ts
+++ b/src/features/theme/theme.ts
@@ -1,0 +1,8 @@
+export function nextTheme(): void {
+  // Use legacy global if available
+  (window as any).VibeMe?.applyRandomTheme?.();
+}
+
+export function setThemeByKey(key: string): void {
+  (window as any).VibeMe?.setThemeByKey?.(key);
+}

--- a/src/features/ui/bindControls.ts
+++ b/src/features/ui/bindControls.ts
@@ -1,0 +1,13 @@
+import { nextTheme, setThemeByKey } from '../theme/theme';
+
+export function bindControls(): void {
+  const darkToggle = document.getElementById('dark-mode-toggle');
+  darkToggle?.addEventListener('click', () => {
+    nextTheme();
+  });
+
+  const presetSelect = document.getElementById('theme-preset') as HTMLSelectElement | null;
+  presetSelect?.addEventListener('change', () => {
+    setThemeByKey(presetSelect.value);
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { bridgeLegacy } from './shell/legacy-bridge';
 import { bootstrap } from './shell/bootstrap';
+import { bindControls } from './features/ui/bindControls';
  
 
 async function main(): Promise<void> {
@@ -7,6 +8,7 @@ async function main(): Promise<void> {
   initMatrix();
   bootstrap();
   bindMatrixUI();
+  bindControls();
 }
 
 void main();


### PR DESCRIPTION
## Summary
- add theme utilities exposing `nextTheme` and `setThemeByKey`
- bind theme control elements to these utilities
- remove direct `window.VibeMe` references from about page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68c35e267b40832bb6b8a512b48e4ad7