### PR TITLE
feat: activate focused buttons via keyboard

### DIFF
--- a/src/features/ui/bindControls.test.ts
+++ b/src/features/ui/bindControls.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { bindControls } from './bindControls';
+import { bus, EVENTS } from '../../lib/bus';
+
+describe('bindControls', () => {
+  it('activates focused buttons on Enter or Space and returns unbinder', () => {
+    document.body.innerHTML = `<button id="generate-btn"></button>`;
+
+    const events: string[] = [];
+    const handler = () => events.push('gen');
+    bus.on(EVENTS.GENERATE_QUOTE, handler);
+
+    const unbind = bindControls();
+
+    const btn = document.getElementById('generate-btn') as HTMLButtonElement;
+    btn.focus();
+
+    btn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    btn.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(events).toEqual(['gen', 'gen']);
+
+    unbind();
+
+    btn.focus();
+    btn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(events).toEqual(['gen', 'gen']);
+
+    bus.off(EVENTS.GENERATE_QUOTE, handler);
+  });
+});
+

--- a/src/features/ui/bindControls.ts
+++ b/src/features/ui/bindControls.ts
@@ -52,11 +52,22 @@ export function bindControls(): () => void {
     })
   );
 
-  const escHandler = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') bus.emit(EVENTS.SEARCH_TOGGLE);
+  const keyHandler = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      bus.emit(EVENTS.SEARCH_TOGGLE);
+      return;
+    }
+
+    if (e.key === 'Enter' || e.key === ' ') {
+      const active = document.activeElement;
+      if (active instanceof HTMLButtonElement) {
+        e.preventDefault();
+        active.click();
+      }
+    }
   };
-  document.addEventListener('keydown', escHandler);
-  offs.push(() => document.removeEventListener('keydown', escHandler));
+  document.addEventListener('keydown', keyHandler);
+  offs.push(() => document.removeEventListener('keydown', keyHandler));
 
   return () => offs.forEach((off) => off());
 }


### PR DESCRIPTION
## Summary
- trigger focused buttons via Enter or Space using a document key handler
- track document listeners with teardown and expose unbind from `bindControls`
- cover keyboard activation and teardown behavior with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7eaaafebc832bb836d5fd463d1f58