### PR TITLE
feat(favorites): panel + a11y + bus-driven add/remove/clear

### DIFF
--- a/src/favorites.js
+++ b/src/favorites.js
@@ -1,237 +1,64 @@
-import { bus, EVENTS } from './lib/bus';
+import { add, all, clear, favoriteId, remove, replaceAll } from './features/favorites/store.ts';
+
+function toText(value) {
+  if (typeof value === 'string') return value.trim();
+  if (value == null) return '';
+  return String(value).trim();
+}
+
+function normalizeQuote(input) {
+  if (!input) return null;
+
+  if (typeof input === 'string') {
+    const text = toText(input);
+    if (!text) return null;
+    return { text, author: null };
+  }
+
+  const text = toText(input.text ?? input.quote ?? input.q);
+  if (!text) return null;
+
+  const authorRaw = input.author ?? input.a ?? null;
+  const authorText = toText(authorRaw);
+  const author = authorText ? authorText : null;
+  return { text, author };
+}
+
+function syncLegacyArray(target) {
+  if (!Array.isArray(target)) return;
+  const snapshot = all().map(({ text, author }) => ({ text, author }));
+  target.splice(0, target.length, ...snapshot);
+}
 
 export function loadFavorites() {
-  try {
-    return JSON.parse(localStorage.getItem('vibeme-favorites') || '[]');
-  } catch {
-    return [];
-  }
+  return all().map(({ text, author }) => ({ text, author }));
 }
 
 export function saveFavorites(favorites) {
-  localStorage.setItem('vibeme-favorites', JSON.stringify(favorites));
-  bus.emit(EVENTS.FAVORITES_CHANGED, favorites);
-  document.dispatchEvent(new CustomEvent(EVENTS.FAVORITES_CHANGED));
+  replaceAll(Array.isArray(favorites) ? favorites : []);
+  syncLegacyArray(favorites);
 }
 
 export function toggleFavorite(favorites, quote) {
-  const existingIndex = favorites.findIndex(
-    (fav) => fav.text === quote.text && fav.author === quote.author
-  );
-  if (existingIndex >= 0) {
-    favorites.splice(existingIndex, 1);
-    saveFavorites(favorites);
+  const normalized = normalizeQuote(quote);
+  if (!normalized) return false;
+
+  const id = favoriteId(normalized.text, normalized.author);
+  if (remove(id)) {
+    syncLegacyArray(favorites);
     return false;
   }
-  favorites.push(quote);
-  saveFavorites(favorites);
+
+  add({ id, text: normalized.text, author: normalized.author });
+  syncLegacyArray(favorites);
   return true;
 }
 
 export function clearFavorites(favorites) {
-  favorites.splice(0, favorites.length);
-  saveFavorites(favorites);
+  clear();
+  syncLegacyArray(favorites);
 }
 
-export function initFavoritesPanel(favorites) {
-  if (window.__favoritesInit) return; // double-load guard
-  window.__favoritesInit = true;
-
-  function $(id) { return document.getElementById(id); }
-
-  function readRaw() {
-    const merge = [];
-    const push = (val) => { if (Array.isArray(val)) merge.push(...val); };
-    push(favorites);
-    try { push(JSON.parse(localStorage.getItem('vibeme-favorites') || '[]')); } catch {}
-    try { push(JSON.parse(localStorage.getItem('favorites') || '[]')); } catch {}
-    try { push(JSON.parse(localStorage.getItem('vibemeFavorites') || '[]')); } catch {}
-    return merge;
-  }
-
-  function saveRaw(raw) {
-    try { localStorage.setItem('vibeme-favorites', JSON.stringify(raw)); } catch {}
-    favorites.length = 0;
-    favorites.push(...raw);
-    refreshCount();
-  }
-
-  function normalize(raw) {
-    const items = (raw || []).map((it) => {
-      if (typeof it === 'string') return { text: it, author: null };
-      if (it && typeof it === 'object') {
-        const text = it.text ?? it.quote ?? it.q ?? '';
-        const author = it.author ?? it.a ?? null;
-        return { text, author };
-      }
-      return { text: String(it ?? ''), author: null };
-    }).filter((x) => x.text);
-    const seen = new Set();
-    return items.filter((x) => {
-      const k = (x.text + '|' + (x.author ?? '')).toLowerCase();
-      if (seen.has(k)) return false;
-      seen.add(k);
-      return true;
-    });
-  }
-
-  function favKey(q) {
-    return ((q?.text ?? '') + '|' + (q?.author ?? '')).toLowerCase();
-  }
-
-  function escapeHTML(s) {
-    return s.replace(/[&<>"']/g, (c) => ({
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#39;',
-    })[c]);
-  }
-
-  function refreshCount(forceN) {
-    const el = $('favorites-count');
-    if (!el) return;
-    if (typeof forceN === 'number') {
-      el.textContent = forceN;
-      return;
-    }
-    el.textContent = normalize(readRaw()).length;
-  }
-
-  function renderList() {
-    const listEl = $('favorites-list');
-    const emptyEl = $('favorites-empty');
-    if (!listEl) return;
-
-    const items = normalize(readRaw());
-    listEl.innerHTML = '';
-    if (!items.length) {
-      if (emptyEl) emptyEl.style.display = '';
-      refreshCount(0);
-      return;
-    }
-    if (emptyEl) emptyEl.style.display = 'none';
-
-    items.forEach((q, idx) => {
-      const row = document.createElement('div');
-      row.className = 'fav-item';
-      row.innerHTML = `
-        <div class="fav-text-wrap">
-          <div class="fav-quote">"${escapeHTML(q.text)}"</div>
-          ${q.author ? `<div class="fav-author">— ${escapeHTML(q.author)}</div>` : ''}
-        </div>
-        <div class="fav-actions">
-          <button class="fav-copy" title="Copy"><i class="fas fa-copy"></i></button>
-          <button class="fav-remove" title="Remove"><i class="fas fa-trash"></i></button>
-        </div>`;
-      row.dataset.index = String(idx);
-      listEl.appendChild(row);
-    });
-
-    listEl.onclick = async (ev) => {
-      const btn = ev.target.closest('button');
-      if (!btn) return;
-
-      const row = ev.target.closest('.fav-item');
-      if (!row) return;
-
-      const idx = Number(row.dataset.index);
-      const itemsNow = normalize(readRaw());
-      const target = itemsNow[idx];
-      if (!target) return;
-
-      if (btn.classList.contains('fav-copy')) {
-        const toCopy = target.text || '';
-        try { await navigator.clipboard?.writeText(toCopy); } catch {}
-        return;
-      }
-
-      if (btn.classList.contains('fav-remove')) {
-        const keyToRemove = favKey(target);
-        const raw = readRaw();
-        let removeAt = -1;
-        for (let i = 0; i < raw.length; i++) {
-          const r = raw[i];
-          const norm = typeof r === 'string'
-            ? { text: r, author: null }
-            : r && typeof r === 'object'
-              ? { text: (r.text ?? r.quote ?? r.q ?? ''), author: (r.author ?? r.a ?? null) }
-              : { text: String(r ?? ''), author: null };
-          if (!norm.text) continue;
-          if (favKey(norm) === keyToRemove) { removeAt = i; break; }
-        }
-        if (removeAt >= 0) {
-          raw.splice(removeAt, 1);
-          saveRaw(raw);
-          renderList();
-        }
-        return;
-      }
-    };
-
-    refreshCount(items.length);
-  }
-
-  (function patchSetItem() {
-    const _set = localStorage.setItem.bind(localStorage);
-    localStorage.setItem = function (k, v) {
-      const r = _set(k, v);
-      if (k === 'vibeme-favorites') {
-        refreshCount();
-        if ($('favorites-panel')?.dataset.state === 'open') renderList();
-      }
-      return r;
-    };
-  })();
-
-  function init() {
-    const toggleBtn = $('favorites-toggle');
-    const panel = $('favorites-panel');
-    const btnClose = $('favorites-close');
-    if (!toggleBtn || !panel || !btnClose) { requestAnimationFrame(init); return; }
-
-    const STATES = { CLOSED: 'closed', OPEN: 'open' };
-    let state = (localStorage.getItem('favorites:state') === 'open') ? 'open' : 'closed';
-
-    function apply(next) {
-      state = next;
-      panel.dataset.state = state;
-      localStorage.setItem('favorites:state', state);
-      if (state === STATES.OPEN) {
-        toggleBtn.setAttribute('aria-label', 'Close favorites');
-        toggleBtn.setAttribute('title', 'Close favorites');
-        toggleBtn.setAttribute('aria-expanded', 'true');
-        panel.setAttribute('aria-modal', 'true');
-        renderList();
-      } else {
-        toggleBtn.setAttribute('aria-label', 'Open favorites');
-        toggleBtn.setAttribute('title', 'Open favorites');
-        toggleBtn.setAttribute('aria-expanded', 'false');
-        panel.setAttribute('aria-modal', 'false');
-      }
-    }
-
-    apply(state);
-
-    toggleBtn.addEventListener('click', (e) => { e.stopPropagation(); apply(state === 'open' ? 'closed' : 'open'); });
-    btnClose.addEventListener('click', (e) => { e.stopPropagation(); apply('closed'); });
-
-    panel.addEventListener('click', (e) => e.stopPropagation());
-    document.addEventListener('click', (e) => {
-      const outside = !panel.contains(e.target) && e.target !== toggleBtn;
-      if (outside && state === 'open') apply('closed');
-    });
-    document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && state === 'open') apply('closed'); });
-
-    window.addEventListener('storage', (ev) => {
-      if (ev.key === 'vibeme-favorites') {
-        refreshCount();
-        if (state === 'open') renderList();
-      }
-    });
-  }
-
-  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
-  else init();
+export function initFavoritesPanel() {
+  // Legacy initializer retained for compatibility; modern panel wiring handles setup.
 }

--- a/src/features/favorites/panel.ts
+++ b/src/features/favorites/panel.ts
@@ -1,0 +1,211 @@
+import type { FavoriteItem } from './store';
+
+type CloseRequester = () => void;
+
+let openerElement: HTMLElement | null = null;
+let teardownFocusTrap: (() => void) | null = null;
+let requestCloseRef: CloseRequester | null = null;
+
+function getPanel(): HTMLElement | null {
+  return document.getElementById('favorites-panel');
+}
+
+function getCountBadge(): HTMLElement | null {
+  return document.getElementById('favorites-count');
+}
+
+function getEmptyState(): HTMLElement | null {
+  return document.getElementById('favorites-empty');
+}
+
+function getListContainer(): HTMLElement | null {
+  return document.getElementById('favorites-list');
+}
+
+function getFocusableElements(root: HTMLElement): HTMLElement[] {
+  const selectors = [
+    'a[href]',
+    'button:not([disabled])',
+    'textarea:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ];
+  return Array.from(root.querySelectorAll<HTMLElement>(selectors.join(','))).filter((el) => {
+    if (el.hasAttribute('inert')) return false;
+    const ariaHidden = el.getAttribute('aria-hidden');
+    if (ariaHidden && ariaHidden.toLowerCase() === 'true') return false;
+    return true;
+  });
+}
+
+function focusFirstElement(panel: HTMLElement): void {
+  const focusable = getFocusableElements(panel);
+  const target = focusable[0] ?? panel;
+  if (panel.tabIndex < 0) {
+    panel.tabIndex = -1;
+  }
+  target.focus({ preventScroll: true });
+}
+
+function handleKeydown(event: KeyboardEvent, panel: HTMLElement): void {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    requestCloseRef?.();
+    return;
+  }
+
+  if (event.key !== 'Tab') {
+    return;
+  }
+
+  const focusable = getFocusableElements(panel);
+  if (!focusable.length) {
+    event.preventDefault();
+    panel.focus({ preventScroll: true });
+    return;
+  }
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement as HTMLElement | null;
+
+  if (event.shiftKey) {
+    if (active === first || !panel.contains(active)) {
+      event.preventDefault();
+      last.focus({ preventScroll: true });
+    }
+    return;
+  }
+
+  if (active === last) {
+    event.preventDefault();
+    first.focus({ preventScroll: true });
+  }
+}
+
+export function openPanel(opener: HTMLElement | null, requestClose: CloseRequester): () => void {
+  const panel = getPanel();
+  if (!panel) {
+    return () => {};
+  }
+
+  openerElement = opener ?? (document.activeElement as HTMLElement | null);
+  requestCloseRef = requestClose;
+
+  panel.dataset.state = 'open';
+  panel.setAttribute('aria-hidden', 'false');
+  panel.setAttribute('aria-modal', 'true');
+  if (!panel.hasAttribute('tabindex')) {
+    panel.tabIndex = -1;
+  }
+
+  const keyHandler = (event: KeyboardEvent) => handleKeydown(event, panel);
+  panel.addEventListener('keydown', keyHandler, true);
+  focusFirstElement(panel);
+
+  teardownFocusTrap = () => {
+    panel.removeEventListener('keydown', keyHandler, true);
+  };
+
+  return teardownFocusTrap;
+}
+
+export function closePanel(): void {
+  const panel = getPanel();
+  if (!panel) {
+    return;
+  }
+
+  panel.dataset.state = 'closed';
+  panel.setAttribute('aria-hidden', 'true');
+  panel.setAttribute('aria-modal', 'false');
+
+  teardownFocusTrap?.();
+  teardownFocusTrap = null;
+  requestCloseRef = null;
+
+  const returnFocusTarget = openerElement;
+  openerElement = null;
+  if (returnFocusTarget && typeof returnFocusTarget.focus === 'function') {
+    returnFocusTarget.focus({ preventScroll: true });
+  }
+}
+
+export function renderFavorites(items: FavoriteItem[]): void {
+  const list = getListContainer();
+  const emptyState = getEmptyState();
+  const badge = getCountBadge();
+
+  const count = items.length;
+
+  if (badge) {
+    badge.textContent = String(count);
+  }
+
+  if (!list) return;
+
+  list.innerHTML = '';
+
+  if (!count) {
+    if (emptyState) {
+      emptyState.style.display = '';
+    }
+    return;
+  }
+
+  if (emptyState) {
+    emptyState.style.display = 'none';
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  for (const item of items) {
+    const row = document.createElement('div');
+    row.className = 'fav-item';
+    row.dataset.favoriteId = item.id;
+
+    const textWrap = document.createElement('div');
+    textWrap.className = 'fav-text-wrap';
+
+    const quoteEl = document.createElement('div');
+    quoteEl.className = 'fav-quote';
+    quoteEl.textContent = `"${item.text}"`;
+    textWrap.appendChild(quoteEl);
+
+    if (item.author) {
+      const authorEl = document.createElement('div');
+      authorEl.className = 'fav-author';
+      authorEl.textContent = `— ${item.author}`;
+      textWrap.appendChild(authorEl);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'fav-actions';
+
+    const shareBtn = document.createElement('button');
+    shareBtn.type = 'button';
+    shareBtn.className = 'fav-share';
+    shareBtn.dataset.action = 'share';
+    shareBtn.title = 'Share quote';
+    shareBtn.setAttribute('aria-label', 'Share quote');
+    shareBtn.innerHTML = '<i class="fas fa-share"></i>';
+    actions.appendChild(shareBtn);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'fav-remove';
+    removeBtn.dataset.action = 'remove';
+    removeBtn.title = 'Remove from favorites';
+    removeBtn.setAttribute('aria-label', 'Remove from favorites');
+    removeBtn.innerHTML = '<i class="fas fa-trash"></i>';
+    actions.appendChild(removeBtn);
+
+    row.appendChild(textWrap);
+    row.appendChild(actions);
+
+    fragment.appendChild(row);
+  }
+
+  list.appendChild(fragment);
+}

--- a/src/features/favorites/store.ts
+++ b/src/features/favorites/store.ts
@@ -1,0 +1,205 @@
+import { bus, EVENTS } from '../../lib/bus';
+import type { Quote } from '../quotes/types';
+
+export interface FavoriteItem {
+  id: string;
+  text: string;
+  author: string | null;
+}
+
+export type FavoriteInput =
+  | string
+  | Partial<FavoriteItem> & {
+      text?: string;
+      quote?: string;
+      author?: string | null;
+    }
+  | Quote;
+
+export const FAVORITES_STORAGE_KEYS = ['vibeme-favorites', 'favorites', 'vibemeFavorites'] as const;
+export const FAVORITES_PRIMARY_STORAGE_KEY = FAVORITES_STORAGE_KEYS[0];
+
+let favorites: FavoriteItem[] = loadFromStorage();
+
+function toText(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (value == null) return '';
+  return String(value).trim();
+}
+
+function toAuthor(value: unknown): string | null {
+  const text = toText(value);
+  return text ? text : null;
+}
+
+export function favoriteId(text: string, author: string | null): string {
+  return `${text.toLowerCase()}|${(author ?? '').toLowerCase()}`;
+}
+
+function normalizeLegacy(value: any): FavoriteItem | null {
+  if (typeof value === 'string') {
+    const text = toText(value);
+    if (!text) return null;
+    return { id: favoriteId(text, null), text, author: null };
+  }
+
+  if (value && typeof value === 'object') {
+    const text = toText(value.text ?? value.quote ?? value.q);
+    if (!text) return null;
+    const author = toAuthor(value.author ?? value.a ?? null);
+    const id = toText((value as FavoriteItem).id) || favoriteId(text, author);
+    return { id, text, author };
+  }
+
+  return null;
+}
+
+function normalizeInput(input: FavoriteInput): FavoriteItem | null {
+  if (typeof input === 'string') {
+    return favorites.find((item) => item.id === input) ?? null;
+  }
+
+  if ('text' in input || 'quote' in input || 'q' in (input as any)) {
+    const text = toText((input as any).text ?? (input as any).quote ?? (input as any).q);
+    if (!text) return null;
+    const author = toAuthor((input as any).author ?? (input as any).a ?? null);
+    const id = toText((input as any).id) || favoriteId(text, author);
+    return { id, text, author };
+  }
+
+  return null;
+}
+
+function dedupe(items: FavoriteItem[]): FavoriteItem[] {
+  const seen = new Set<string>();
+  const result: FavoriteItem[] = [];
+  for (const item of items) {
+    if (!item.id) continue;
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    result.push(item);
+  }
+  return result;
+}
+
+function loadFromStorage(): FavoriteItem[] {
+  const collected: FavoriteItem[] = [];
+
+  for (const key of FAVORITES_STORAGE_KEYS) {
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) continue;
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        for (const entry of parsed) {
+          const normalized = normalizeLegacy(entry);
+          if (normalized) {
+            collected.push(normalized);
+          }
+        }
+      }
+    } catch (error) {
+      console.warn('[favorites] failed to read', key, error);
+    }
+  }
+
+  return dedupe(collected);
+}
+
+function persist(): void {
+  try {
+    localStorage.setItem(FAVORITES_PRIMARY_STORAGE_KEY, JSON.stringify(favorites));
+  } catch (error) {
+    console.warn('[favorites] failed to persist', error);
+  }
+}
+
+function emitChanged(): void {
+  bus.emit(EVENTS.FAV_CHANGED, { count: favorites.length });
+}
+
+function replaceInternal(items: FavoriteItem[]): void {
+  favorites = dedupe(items);
+  persist();
+  emitChanged();
+}
+
+function areListsEqual(a: FavoriteItem[], b: FavoriteItem[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const left = a[i];
+    const right = b[i];
+    if (!left || !right) return false;
+    if (left.id !== right.id || left.text !== right.text || left.author !== right.author) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function all(): FavoriteItem[] {
+  return favorites.map((item) => ({ ...item }));
+}
+
+export function get(id: string): FavoriteItem | undefined {
+  return favorites.find((item) => item.id === id);
+}
+
+export function add(input: FavoriteInput): FavoriteItem | null {
+  const normalized = normalizeInput(input);
+  if (!normalized) return null;
+
+  const existingIndex = favorites.findIndex((item) => item.id === normalized.id);
+  if (existingIndex >= 0) {
+    const existing = favorites[existingIndex];
+    if (existing.text !== normalized.text || existing.author !== normalized.author) {
+      favorites[existingIndex] = normalized;
+      persist();
+      emitChanged();
+    }
+    return favorites[existingIndex];
+  }
+
+  favorites.push(normalized);
+  persist();
+  emitChanged();
+  return normalized;
+}
+
+export function remove(id: string): boolean {
+  const index = favorites.findIndex((item) => item.id === id);
+  if (index === -1) {
+    return false;
+  }
+
+  favorites.splice(index, 1);
+  persist();
+  emitChanged();
+  return true;
+}
+
+export function clear(): void {
+  if (!favorites.length) return;
+  favorites = [];
+  persist();
+  emitChanged();
+}
+
+export function replaceAll(inputs: FavoriteInput[]): void {
+  const normalized: FavoriteItem[] = [];
+  for (const input of inputs) {
+    const item = normalizeLegacy(input) ?? normalizeInput(input);
+    if (item) {
+      normalized.push(item);
+    }
+  }
+  replaceInternal(normalized);
+}
+
+export function reloadFromStorage(): void {
+  const loaded = loadFromStorage();
+  if (!areListsEqual(loaded, favorites)) {
+    favorites = loaded;
+    emitChanged();
+  }
+}

--- a/src/features/favorites/wiring.ts
+++ b/src/features/favorites/wiring.ts
@@ -1,0 +1,210 @@
+import { bus, EVENTS } from '../../lib/bus';
+import { FAVORITES_STORAGE_KEYS, all, clear, get, reloadFromStorage, remove } from './store';
+import { closePanel, openPanel, renderFavorites } from './panel';
+
+type OpenPayload = { opener?: HTMLElement | null } | undefined;
+
+const PANEL_STATE_STORAGE_KEY = 'favorites:state';
+
+function getToggleButton(): HTMLElement | null {
+  return document.getElementById('favorites-toggle');
+}
+
+function getPanelElement(): HTMLElement | null {
+  return document.getElementById('favorites-panel');
+}
+
+function getListElement(): HTMLElement | null {
+  return document.getElementById('favorites-list');
+}
+
+function updateToggleButton(state: 'open' | 'closed'): void {
+  const toggle = getToggleButton();
+  if (!toggle) return;
+
+  if (state === 'open') {
+    toggle.setAttribute('aria-expanded', 'true');
+    toggle.setAttribute('aria-label', 'Close favorites');
+    toggle.setAttribute('title', 'Close favorites');
+  } else {
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-label', 'Open favorites');
+    toggle.setAttribute('title', 'Open favorites');
+  }
+}
+
+function applyPanelState(state: 'open' | 'closed'): void {
+  const panel = getPanelElement();
+  if (!panel) return;
+
+  panel.dataset.state = state;
+  panel.setAttribute('aria-hidden', state === 'open' ? 'false' : 'true');
+  panel.setAttribute('aria-modal', state === 'open' ? 'true' : 'false');
+}
+
+async function shareFavorite(id: string): Promise<void> {
+  const item = get(id);
+  if (!item) return;
+
+  const text = item.author ? `${item.text} — ${item.author}` : item.text;
+
+  if (navigator.share) {
+    try {
+      await navigator.share({ text });
+      return;
+    } catch {
+      // fall through to clipboard fallback
+    }
+  }
+
+  try {
+    await navigator.clipboard?.writeText(text);
+  } catch {
+    // no-op: failing to copy shouldn't break the flow
+  }
+}
+
+function setupFavorites(): () => void {
+  renderFavorites(all());
+  updateToggleButton('closed');
+  applyPanelState('closed');
+
+  const list = getListElement();
+  const panel = getPanelElement();
+  const toggle = getToggleButton();
+
+  let isOpen = false;
+  let releaseFocus: (() => void) | null = null;
+
+  const requestClose = () => {
+    bus.emit(EVENTS.FAV_CLOSE);
+  };
+
+  const handleOpen = (payload?: OpenPayload) => {
+    if (isOpen) return;
+
+    const opener = (payload?.opener ?? toggle) ?? null;
+    releaseFocus?.();
+    releaseFocus = openPanel(opener, requestClose);
+    isOpen = true;
+    updateToggleButton('open');
+    applyPanelState('open');
+    try {
+      localStorage.setItem(PANEL_STATE_STORAGE_KEY, 'open');
+    } catch {
+      /* ignore storage errors */
+    }
+  };
+
+  const handleClose = () => {
+    if (!isOpen) return;
+
+    releaseFocus?.();
+    releaseFocus = null;
+    closePanel();
+    isOpen = false;
+    updateToggleButton('closed');
+    applyPanelState('closed');
+    try {
+      localStorage.setItem(PANEL_STATE_STORAGE_KEY, 'closed');
+    } catch {
+      /* ignore storage errors */
+    }
+  };
+
+  const handleChanged = () => {
+    renderFavorites(all());
+  };
+
+  const handleOutsideClick = (event: MouseEvent) => {
+    if (!isOpen) return;
+    const target = event.target as Node | null;
+    if (!panel?.contains(target) && target !== toggle) {
+      bus.emit(EVENTS.FAV_CLOSE);
+    }
+  };
+
+  const handleListClick = (event: MouseEvent) => {
+    const actionEl = (event.target as HTMLElement | null)?.closest<HTMLElement>('[data-action]');
+    if (!actionEl || !list?.contains(actionEl)) return;
+
+    const action = actionEl.dataset.action;
+    const row = actionEl.closest<HTMLElement>('[data-favorite-id]');
+    const id = row?.dataset.favoriteId;
+    if (!id) return;
+
+    if (action === 'remove') {
+      event.preventDefault();
+      remove(id);
+      return;
+    }
+
+    if (action === 'share') {
+      event.preventDefault();
+      void shareFavorite(id);
+    }
+  };
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key && FAVORITES_STORAGE_KEYS.includes(event.key)) {
+      reloadFromStorage();
+    }
+  };
+
+  const handleClear = () => {
+    clear();
+  };
+
+  bus.on(EVENTS.FAV_OPEN, handleOpen);
+  bus.on(EVENTS.FAV_CLOSE, handleClose);
+  bus.on(EVENTS.FAV_CHANGED, handleChanged);
+  bus.on(EVENTS.FAV_CLEAR, handleClear);
+
+  document.addEventListener('click', handleOutsideClick);
+  list?.addEventListener('click', handleListClick);
+  window.addEventListener('storage', handleStorage);
+
+  const restore = () => {
+    try {
+      const saved = localStorage.getItem(PANEL_STATE_STORAGE_KEY);
+      if (saved === 'open') {
+        bus.emit(EVENTS.FAV_OPEN, { opener: toggle ?? null });
+      }
+    } catch {
+      /* ignore */
+    }
+  };
+
+  restore();
+
+  return () => {
+    bus.off(EVENTS.FAV_OPEN, handleOpen);
+    bus.off(EVENTS.FAV_CLOSE, handleClose);
+    bus.off(EVENTS.FAV_CHANGED, handleChanged);
+    bus.off(EVENTS.FAV_CLEAR, handleClear);
+
+    document.removeEventListener('click', handleOutsideClick);
+    list?.removeEventListener('click', handleListClick);
+    window.removeEventListener('storage', handleStorage);
+
+    releaseFocus?.();
+  };
+}
+
+export function initFavorites(): () => void {
+  if (document.readyState === 'loading') {
+    let teardown: (() => void) | null = null;
+    const onReady = () => {
+      document.removeEventListener('DOMContentLoaded', onReady);
+      teardown = setupFavorites();
+    };
+    document.addEventListener('DOMContentLoaded', onReady);
+    return () => {
+      document.removeEventListener('DOMContentLoaded', onReady);
+      teardown?.();
+      teardown = null;
+    };
+  }
+
+  return setupFavorites();
+}

--- a/src/features/ui/bindControls.ts
+++ b/src/features/ui/bindControls.ts
@@ -57,7 +57,7 @@ export function bindControls(): () => void {
       bus.emit(EVENTS.MATRIX_TOGGLE, (e.target as HTMLInputElement).checked)
     )
   );
-  offs.push(on('clear-favorites-btn', 'click', () => bus.emit(EVENTS.FAVORITES_CLEAR)));
+  offs.push(on('clear-favorites-btn', 'click', () => bus.emit(EVENTS.FAV_CLEAR)));
   offs.push(on('toggle-add-quote-form', 'click', () => bus.emit(EVENTS.QUOTE_FORM_TOGGLE)));
   offs.push(on('submit-quote-btn', 'click', () => bus.emit(EVENTS.QUOTE_SUBMIT)));
   offs.push(
@@ -96,6 +96,27 @@ export function bindControls(): () => void {
   };
   document.addEventListener('keydown', keyHandler);
   offs.push(() => document.removeEventListener('keydown', keyHandler));
+
+  const toggleFavorites = document.getElementById('favorites-toggle');
+  if (toggleFavorites) {
+    const handleToggle = (event: Event) => {
+      event.preventDefault();
+      const expanded = toggleFavorites.getAttribute('aria-expanded') === 'true';
+      bus.emit(expanded ? EVENTS.FAV_CLOSE : EVENTS.FAV_OPEN, { opener: toggleFavorites });
+    };
+    toggleFavorites.addEventListener('click', handleToggle);
+    offs.push(() => toggleFavorites.removeEventListener('click', handleToggle));
+  }
+
+  const favoritesClose = document.getElementById('favorites-close');
+  if (favoritesClose) {
+    const handleClose = (event: Event) => {
+      event.preventDefault();
+      bus.emit(EVENTS.FAV_CLOSE);
+    };
+    favoritesClose.addEventListener('click', handleClose);
+    offs.push(() => favoritesClose.removeEventListener('click', handleClose));
+  }
 
   return () => offs.forEach((off) => off());
 }

--- a/src/lib/bus.ts
+++ b/src/lib/bus.ts
@@ -43,8 +43,11 @@ export const SEARCH_TOGGLE = 'SEARCH_TOGGLE';
 export const SEARCH_QUERY = 'SEARCH_QUERY';
 export const QUOTES_READY = 'QUOTES_READY';
 export const QUOTE_STATS_UPDATED = 'QUOTE_STATS_UPDATED';
-export const QUOTE_RATED = 'QUOTE_RATED';
 export const QUOTE_CATEGORY_CHANGED = 'QUOTE_CATEGORY_CHANGED';
+export const FAV_OPEN = 'fav:open';
+export const FAV_CLOSE = 'fav:close';
+export const FAV_CLEAR = 'fav:clear';
+export const FAV_CHANGED = 'fav:changed';
 
 export const EVENTS = {
   QUOTE_REQUEST,
@@ -69,7 +72,10 @@ export const EVENTS = {
   SEARCH_QUERY,
   QUOTES_READY,
   QUOTE_STATS_UPDATED,
-  QUOTE_RATED,
   QUOTE_CATEGORY_CHANGED,
+  FAV_OPEN,
+  FAV_CLOSE,
+  FAV_CLEAR,
+  FAV_CHANGED,
 } as const;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { bridgeLegacy } from './shell/legacy-bridge';
 import { bootstrap } from './shell/bootstrap';
 import { bindControls } from './features/ui/bindControls';
 import './features/quotes';
+import { initFavorites } from './features/favorites/wiring';
  
 
 async function main(): Promise<void> {
@@ -10,6 +11,7 @@ async function main(): Promise<void> {
   bootstrap();
   bindMatrixUI();
   bindControls();
+  initFavorites();
 }
 
 void main();


### PR DESCRIPTION
## Summary
- add a favorites store module that normalizes data, syncs with localStorage, and emits bus updates
- create an accessible favorites panel with focus trapping, dynamic rendering, and event delegation for share/remove actions
- wire UI controls and legacy shims to the new bus events so favorites open/close/clear without touching window globals

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca98a03c68832b8d6aa273af34b0b1