### PR TITLE
feat: scaffold svelte shell for framework migration

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -177,6 +177,19 @@ body { min-height: 100dvh; height: 100dvh; overflow: hidden !important; padding:
   margin-right: auto;
 }
 
+body.has-svelte-app #quote-text,
+body.has-svelte-app #quote-author {
+  visibility: hidden;
+}
+
+body.has-svelte-app section[aria-label="Quote actions"],
+body.has-svelte-app section[aria-label="Quote generation"],
+body.has-svelte-app #favorites-panel,
+body.has-svelte-app #favorites-toggle,
+body.has-svelte-app #settings-panel {
+  display: none !important;
+}
+
 /* Ensure inner card never pushes the page taller than the viewport */
 .quote-container-inner {
   max-height: calc(100dvh - 160px); /* room for title, clock, buttons */

--- a/index.html
+++ b/index.html
@@ -400,6 +400,7 @@
 
     <!-- Main content -->
     <main id="main-content" class="w-full relative z-10 p-4 sm:p-6 lg:p-8">
+        <div id="app" class="relative z-[2000]"></div>
         <div id="quote-live" aria-live="polite" class="sr-only"></div>
         <!-- App Title Bar (centered, outside the quote box) -->
         <div id="app-title-bar" class="app-title-bar" role="banner" aria-label="Application Title">
@@ -635,6 +636,9 @@
       }
     </script>
     
+
+    <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="/src/app/main.ts"></script>
 
     <!-- Fallback for browsers without script support -->
     <noscript>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,29 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^3.0.2",
+        "@tsconfig/svelte": "^5.0.0",
         "jsdom": "^22.1.0",
+        "svelte": "^4.2.12",
+        "svelte-check": "^3.6.7",
+        "tslib": "^2.6.2",
+        "typescript": "^5.4.2",
+        "vite": "^5.2.11",
         "vitest": "^0.34.6"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -417,12 +438,44 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.50.1",
@@ -725,6 +778,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.2.tgz",
+      "integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
+        "debug": "^4.3.4",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.10",
+        "svelte-hmr": "^0.16.0",
+        "vitefu": "^0.2.5"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-2.1.0.tgz",
+      "integrity": "sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^3.0.0",
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "vite": "^5.0.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -734,6 +828,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@tsconfig/svelte": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.5.tgz",
+      "integrity": "sha512-48fAnUjKye38FvMiNOj0J9I/4XlQQiZlpe9xaNPfe8vy2Y1hFBt8g1yqf2EGjVvHavo4jf2lC+TQyENCr4BJBQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "4.3.20",
@@ -768,6 +869,13 @@
       "dependencies": {
         "undici-types": "~7.10.0"
       }
+    },
+    "node_modules/@types/pug": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
+      "integrity": "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "0.34.6",
@@ -902,6 +1010,30 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -918,6 +1050,70 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -975,6 +1171,45 @@
         "node": "*"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/code-red": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
+      "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@types/estree": "^1.0.1",
+        "acorn": "^8.10.0",
+        "estree-walker": "^3.0.3",
+        "periscopic": "^3.1.0"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -988,12 +1223,33 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
     },
     "node_modules/cssstyle": {
       "version": "3.0.0",
@@ -1061,6 +1317,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1069,6 +1335,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff-sequences": {
@@ -1172,6 +1448,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -1211,6 +1494,29 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
@@ -1227,6 +1533,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1302,6 +1615,41 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1314,6 +1662,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -1412,12 +1767,87 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
     },
     "node_modules/jsdom": {
       "version": "22.1.0",
@@ -1462,6 +1892,16 @@
         }
       }
     },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
@@ -1474,6 +1914,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "2.3.7",
@@ -1505,6 +1952,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -1528,6 +1982,52 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mlly": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
@@ -1547,6 +2047,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1574,12 +2084,32 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.22",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
       "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/p-limit": {
       "version": "4.0.0",
@@ -1610,6 +2140,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -1627,12 +2167,37 @@
         "node": "*"
       }
     },
+    "node_modules/periscopic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+      "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "is-reference": "^3.0.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pkg-types": {
       "version": "1.3.1",
@@ -1734,12 +2299,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
     },
     "node_modules/rollup": {
       "version": "4.50.1",
@@ -1789,12 +2381,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sander": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+      "integrity": "sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^3.1.2",
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -1815,6 +2433,22 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sorcery": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.11.1.tgz",
+      "integrity": "sha512-o7npfeJE6wi6J9l0/5LKshFzZ2rMatRiCDwYeDQaOzqdzRJwALhX7mk/A/ecg6wjMu7wdZbmXfD2S/vpOg0bdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.14",
+        "buffer-crc32": "^1.0.0",
+        "minimist": "^1.2.0",
+        "sander": "^0.5.0"
+      },
+      "bin": {
+        "sorcery": "bin/sorcery"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1840,6 +2474,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz",
@@ -1851,6 +2498,129 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.20.tgz",
+      "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/estree": "^1.0.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
+        "axobject-query": "^4.0.0",
+        "code-red": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "estree-walker": "^3.0.3",
+        "is-reference": "^3.0.1",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.4",
+        "periscopic": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.8.6.tgz",
+      "integrity": "sha512-ij0u4Lw/sOTREP13BdWZjiXD/BlHE6/e2e34XzmVmsp5IN4kVa3PWP65NM32JAgwjZlwBg/+JtiNV1MM8khu0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "chokidar": "^3.4.1",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4",
+        "svelte-preprocess": "^5.1.3",
+        "typescript": "^5.0.3"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "peerDependencies": {
+        "svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0"
+      }
+    },
+    "node_modules/svelte-hmr": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.16.0.tgz",
+      "integrity": "sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.20 || ^14.13.1 || >= 16"
+      },
+      "peerDependencies": {
+        "svelte": "^3.19.0 || ^4.0.0"
+      }
+    },
+    "node_modules/svelte-preprocess": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.1.4.tgz",
+      "integrity": "sha512-IvnbQ6D6Ao3Gg6ftiM5tdbR6aAETwjhHV+UKGf5bHGYR69RQvF1ho0JKPcbUON4vy4R7zom13jPjgdOWCQ5hDA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/pug": "^2.0.6",
+        "detect-indent": "^6.1.0",
+        "magic-string": "^0.30.5",
+        "sorcery": "^0.11.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.10.2",
+        "coffeescript": "^2.5.1",
+        "less": "^3.11.3 || ^4.0.0",
+        "postcss": "^7 || ^8",
+        "postcss-load-config": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+        "pug": "^3.0.0",
+        "sass": "^1.26.8",
+        "stylus": "^0.55.0",
+        "sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "svelte": "^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=3.9.5 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "coffeescript": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "postcss-load-config": {
+          "optional": true
+        },
+        "pug": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/symbol-tree": {
@@ -1887,6 +2657,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -1916,6 +2699,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/type-detect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
@@ -1924,6 +2714,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/ufo": {
@@ -2043,6 +2847,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
+      "integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vitest": {
@@ -2199,6 +3018,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.3",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "name": "vibeme",
   "version": "1.0.0",
   "description": "A beautiful motivational quote generator with dynamic themes and inspiring messages",
-  
   "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
     "sync-quotes": "node scripts/sync-quotes.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "keywords": [
     "quotes",
@@ -15,7 +18,14 @@
   "author": "VibeMe",
   "license": "ISC",
   "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^3.0.2",
+    "@tsconfig/svelte": "^5.0.0",
     "jsdom": "^22.1.0",
+    "svelte": "^4.2.12",
+    "svelte-check": "^3.6.7",
+    "tslib": "^2.6.2",
+    "typescript": "^5.4.2",
+    "vite": "^5.2.11",
     "vitest": "^0.34.6"
   }
 }

--- a/src/app/AppShell.svelte
+++ b/src/app/AppShell.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import MatrixLayer from './features/matrix/MatrixLayer.svelte';
+  import ControlsBar from './components/ControlsBar.svelte';
+  import HeaderBar from './components/HeaderBar.svelte';
+  import QuoteCard from './components/QuoteCard.svelte';
+  import FavoritesPanel from './panels/FavoritesPanel.svelte';
+  import SettingsPanel from './panels/SettingsPanel.svelte';
+  import { currentQuote, ensureInitialQuote, type QuoteViewModel } from './stores/quote';
+
+  let quote: QuoteViewModel | null = null;
+  let settingsOpen = false;
+
+  const unsubscribe = currentQuote.subscribe((value) => {
+    quote = value;
+  });
+
+  onMount(() => {
+    document.body.classList.add('has-svelte-app');
+    ensureInitialQuote();
+  });
+
+  onDestroy(() => {
+    document.body.classList.remove('has-svelte-app');
+    unsubscribe();
+  });
+
+  function openSettings(): void {
+    settingsOpen = true;
+  }
+
+  function closeSettings(): void {
+    settingsOpen = false;
+  }
+</script>
+
+<MatrixLayer />
+
+<div class="relative z-[100] mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-12">
+  <HeaderBar {quote} onOpenSettings={openSettings} />
+  <QuoteCard {quote} />
+  <ControlsBar {quote} />
+</div>
+
+<FavoritesPanel />
+<SettingsPanel open={settingsOpen} onClose={closeSettings} />

--- a/src/app/components/ControlsBar.svelte
+++ b/src/app/components/ControlsBar.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import type { Quote } from '../../features/quotes/types';
+  import { bumpRating, getRating, loadRatings, persistRatings } from '../../features/quotes/rating';
+  import { bus, EVENTS } from '../../lib/bus';
+  import { isFavorite, openFavorites, toggleFavorite } from '../stores/favorites';
+  import type { QuoteViewModel } from '../stores/quote';
+  import { requestNextQuote } from '../stores/quote';
+
+  const ratings = loadRatings();
+
+  export let quote: QuoteViewModel | null = null;
+
+  $: currentRating = quote ? getRating(ratings, toQuote(quote)) : { up: 0, down: 0 };
+  $: favoriteActive = isFavorite(quote);
+
+  function toQuote(value: QuoteViewModel): Quote {
+    return {
+      text: value.text,
+      author: value.author ?? 'Unknown',
+      category: value.category ?? 'default',
+    };
+  }
+
+  function actionText(): string | null {
+    if (!quote || !quote.text?.trim()) return null;
+    const text = quote.text.trim();
+    const author = quote.author?.trim();
+    return author ? `${text} — ${author}` : text;
+  }
+
+  async function copyQuote(): Promise<void> {
+    const text = actionText();
+    if (!text) return;
+    try {
+      await navigator.clipboard?.writeText(text);
+    } catch {
+      /* ignore clipboard failures */
+    }
+  }
+
+  async function shareQuote(): Promise<void> {
+    const text = actionText();
+    if (!text) return;
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ text });
+        return;
+      } catch {
+        /* fall through */
+      }
+    }
+
+    try {
+      await navigator.clipboard?.writeText(text);
+    } catch {
+      /* ignore clipboard failures */
+    }
+  }
+
+  function handleFavorite(): void {
+    toggleFavorite(quote);
+  }
+
+  function handleGenerate(): void {
+    requestNextQuote({ source: 'svelte:controls' });
+  }
+
+  function rate(direction: 'up' | 'down'): void {
+    if (!quote) return;
+    const next = bumpRating(ratings, toQuote(quote), direction);
+    persistRatings(ratings);
+    currentRating = next;
+    bus.emit(EVENTS.QUOTE_RATED, { direction, quote });
+  }
+</script>
+
+<div class="mt-8 flex flex-col items-center gap-6 text-white">
+  <div class="flex items-center justify-center gap-3 text-lg">
+    <button
+      type="button"
+      class="group rounded-full bg-white/10 p-3 transition hover:bg-white/20"
+      aria-label="Copy quote"
+      on:click={copyQuote}
+    >
+      <i class="fas fa-copy text-white/80 group-hover:text-white" aria-hidden="true" />
+    </button>
+
+    <button
+      type="button"
+      class={`group rounded-full p-3 transition ${favoriteActive ? 'bg-pink-500/80' : 'bg-white/10 hover:bg-white/20'}`}
+      aria-label={favoriteActive ? 'Remove from favorites' : 'Add to favorites'}
+      on:click={handleFavorite}
+    >
+      <i
+        class={`fas ${favoriteActive ? 'fa-heart' : 'fa-heart-circle-plus'} text-white`}
+        aria-hidden="true"
+      />
+    </button>
+
+    <button
+      type="button"
+      class="group rounded-full bg-white/10 p-3 transition hover:bg-white/20"
+      aria-label="Share quote"
+      on:click={shareQuote}
+    >
+      <i class="fas fa-share-nodes text-white/80 group-hover:text-white" aria-hidden="true" />
+    </button>
+
+    <button
+      type="button"
+      class="group rounded-full bg-white/10 px-4 py-2 text-sm transition hover:bg-white/20"
+      aria-label="Open favorites"
+      on:click={(event) => openFavorites(event.currentTarget as HTMLElement)}
+    >
+      Favorites
+    </button>
+  </div>
+
+  <div class="flex items-center gap-3 text-base text-white/80">
+    <button
+      type="button"
+      class="inline-flex items-center gap-2 rounded-full bg-emerald-500/80 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500"
+      aria-label="Rate quote positively"
+      on:click={() => rate('up')}
+    >
+      <i class="fas fa-thumbs-up" aria-hidden="true" />
+      <span>{currentRating.up}</span>
+    </button>
+
+    <button
+      type="button"
+      class="inline-flex items-center gap-2 rounded-full bg-rose-500/80 px-4 py-2 text-sm font-semibold text-white transition hover:bg-rose-500"
+      aria-label="Rate quote negatively"
+      on:click={() => rate('down')}
+    >
+      <i class="fas fa-thumbs-down" aria-hidden="true" />
+      <span>{currentRating.down}</span>
+    </button>
+  </div>
+
+  <button
+    type="button"
+    class="group inline-flex items-center gap-2 rounded-full bg-white/15 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white transition hover:bg-white/25"
+    on:click={handleGenerate}
+  >
+    <i class="fas fa-wand-magic-sparkles text-white/80 group-hover:text-white" aria-hidden="true" />
+    New Vibe
+  </button>
+</div>

--- a/src/app/components/HeaderBar.svelte
+++ b/src/app/components/HeaderBar.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { bus, EVENTS } from '../../lib/bus';
+  import { openFavorites } from '../stores/favorites';
+  import type { QuoteViewModel } from '../stores/quote';
+
+  export let quote: QuoteViewModel | null = null;
+  export let onOpenSettings: () => void = () => {};
+
+  let favoritesButton: HTMLButtonElement | null = null;
+
+  function handleTheme(): void {
+    bus.emit(EVENTS.THEME_CHANGED, { action: 'next' });
+  }
+
+  function handleFavorites(): void {
+    openFavorites(favoritesButton ?? undefined);
+  }
+</script>
+
+<header class="flex flex-wrap items-center justify-between gap-4 text-white">
+  <div>
+    <h1 class="text-3xl font-semibold tracking-tight heading-font">VibeMe</h1>
+    {#if quote?.category}
+      <p class="text-sm text-white/70">Exploring {quote.category} vibes</p>
+    {/if}
+  </div>
+
+  <div class="flex items-center gap-2">
+    <button
+      type="button"
+      class="rounded-full bg-white/10 p-2 text-white transition hover:bg-white/20"
+      aria-label="Shuffle theme"
+      on:click={handleTheme}
+    >
+      <i class="fas fa-palette" aria-hidden="true" />
+    </button>
+
+    <button
+      type="button"
+      class="rounded-full bg-white/10 p-2 text-white transition hover:bg-white/20"
+      aria-label="Open favorites"
+      bind:this={favoritesButton}
+      on:click={handleFavorites}
+    >
+      <i class="fas fa-bookmark" aria-hidden="true" />
+    </button>
+
+    <button
+      type="button"
+      class="rounded-full bg-white/10 p-2 text-white transition hover:bg-white/20"
+      aria-label="Open settings"
+      on:click={onOpenSettings}
+    >
+      <i class="fas fa-gear" aria-hidden="true" />
+    </button>
+  </div>
+</header>

--- a/src/app/components/Modal.svelte
+++ b/src/app/components/Modal.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import { createEventDispatcher, onDestroy, onMount, tick } from 'svelte';
+
+  const FOCUSABLE = '[tabindex]:not([tabindex="-1"]),a[href],button:not([disabled]),input:not([disabled]),textarea:not([disabled]),select:not([disabled])';
+
+  export let open = false;
+  export let labelledBy: string | undefined;
+  export let describedBy: string | undefined;
+  export let returnFocus: HTMLElement | null = null;
+  export let closeOnBackdrop = true;
+
+  const dispatch = createEventDispatcher<{ close: void }>();
+
+  let dialog: HTMLDivElement | null = null;
+  let previouslyFocused: Element | null = null;
+
+  function getFocusable(): HTMLElement[] {
+    if (!dialog) return [];
+    return Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE)).filter((el) => !el.hasAttribute('disabled'));
+  }
+
+  function focusFirst(): void {
+    const focusable = getFocusable();
+    if (focusable.length > 0) {
+      focusable[0].focus();
+    } else {
+      dialog?.focus();
+    }
+  }
+
+  function trapFocus(event: KeyboardEvent): void {
+    if (event.key !== 'Tab' || !dialog) return;
+    const focusable = getFocusable();
+    if (!focusable.length) {
+      event.preventDefault();
+      dialog.focus();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+
+    if (event.shiftKey) {
+      if (active === first || active === dialog) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (!open) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      dispatch('close');
+      return;
+    }
+    trapFocus(event);
+  }
+
+  function handleBackdrop(event: MouseEvent): void {
+    if (!closeOnBackdrop) return;
+    if (event.target === event.currentTarget) {
+      dispatch('close');
+    }
+  }
+
+  onMount(() => {
+    document.addEventListener('keydown', handleKeydown, true);
+  });
+
+  onDestroy(() => {
+    document.removeEventListener('keydown', handleKeydown, true);
+  });
+
+  $: if (open) {
+    previouslyFocused = document.activeElement;
+    tick().then(() => {
+      focusFirst();
+    });
+  } else if (!open && previouslyFocused instanceof HTMLElement) {
+    (returnFocus ?? previouslyFocused).focus?.();
+    previouslyFocused = null;
+  }
+</script>
+
+{#if open}
+  <svelte:teleport to="body">
+    <div
+      class="fixed inset-0 z-[10050] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      role="presentation"
+      on:click={handleBackdrop}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={labelledBy}
+        aria-describedby={describedBy}
+        class="w-full max-w-xl rounded-2xl bg-slate-900/90 text-slate-100 shadow-2xl border border-white/10"
+        tabindex="-1"
+        bind:this={dialog}
+      >
+        <slot />
+      </div>
+    </div>
+  </svelte:teleport>
+{/if}

--- a/src/app/components/QuoteCard.svelte
+++ b/src/app/components/QuoteCard.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import type { QuoteViewModel } from '../stores/quote';
+
+  export let quote: QuoteViewModel | null = null;
+</script>
+
+<section
+  class="relative overflow-hidden rounded-3xl border border-white/10 bg-white/10 p-6 text-center text-white shadow-2xl backdrop-blur-xl"
+  aria-live="polite"
+  aria-atomic="true"
+>
+  <div class="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-white/5" aria-hidden="true" />
+
+  <p class="quote-text-font text-2xl leading-relaxed md:text-3xl">
+    {#if quote?.text}
+      {quote.text}
+    {:else}
+      Loading your next dose of inspiration…
+    {/if}
+  </p>
+
+  <footer class="mt-6 text-base italic text-white/80">
+    {#if quote?.author}
+      — {quote.author}
+    {:else if quote?.text}
+      — Unknown
+    {/if}
+  </footer>
+
+  {#if quote?.category}
+    <span class="mt-6 inline-flex items-center rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-wider text-white/70">
+      {quote.category}
+    </span>
+  {/if}
+</section>

--- a/src/app/features/matrix/MatrixLayer.svelte
+++ b/src/app/features/matrix/MatrixLayer.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { initMatrix, teardownMatrix, updateMatrix } from '../../../features/matrix/engine';
+
+  export let enabled = true;
+
+  let initialized = false;
+
+  onMount(() => {
+    if (enabled && !initialized) {
+      initMatrix();
+      initialized = true;
+    }
+  });
+
+  onDestroy(() => {
+    if (initialized) {
+      teardownMatrix();
+      initialized = false;
+    }
+  });
+
+  $: if (enabled) {
+    if (!initialized) {
+      initMatrix();
+      initialized = true;
+    } else {
+      updateMatrix();
+    }
+  } else if (initialized) {
+    teardownMatrix();
+    initialized = false;
+  }
+</script>

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,0 +1,7 @@
+import AppShell from './AppShell.svelte';
+
+const target = document.getElementById('app');
+
+if (target) {
+  new AppShell({ target });
+}

--- a/src/app/panels/FavoritesPanel.svelte
+++ b/src/app/panels/FavoritesPanel.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { bus, EVENTS } from '../../lib/bus';
+  import type { FavoriteItem } from '../../features/favorites/store';
+  import Modal from '../components/Modal.svelte';
+  import {
+    clearFavorites,
+    closeFavorites,
+    favorites,
+    removeFavorite,
+    shareFavoriteById,
+  } from '../stores/favorites';
+
+  let open = false;
+  let opener: HTMLElement | null = null;
+  let items: FavoriteItem[] = [];
+
+  const unsubscribe = favorites.subscribe((value) => {
+    items = value;
+  });
+
+  function handleOpen(payload?: { opener?: HTMLElement | null }): void {
+    open = true;
+    opener = payload?.opener ?? null;
+  }
+
+  function handleClose(): void {
+    open = false;
+  }
+
+  onMount(() => {
+    bus.on(EVENTS.FAV_OPEN, handleOpen);
+    bus.on(EVENTS.FAV_CLOSE, handleClose);
+  });
+
+  onDestroy(() => {
+    bus.off(EVENTS.FAV_OPEN, handleOpen);
+    bus.off(EVENTS.FAV_CLOSE, handleClose);
+    unsubscribe();
+  });
+
+  function onRequestClose(): void {
+    closeFavorites();
+  }
+
+  async function onShare(id: string): Promise<void> {
+    await shareFavoriteById(id);
+  }
+
+  function onRemove(id: string): void {
+    removeFavorite(id);
+  }
+
+  function onClear(): void {
+    clearFavorites();
+  }
+</script>
+
+<Modal open={open} on:close={onRequestClose} labelledBy="favorites-title" returnFocus={opener}>
+  <div class="flex items-center justify-between border-b border-white/10 px-5 py-4">
+    <div class="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-white/80">
+      <i class="fas fa-bookmark text-xs" aria-hidden="true" />
+      <span id="favorites-title">Favorites</span>
+      <span class="rounded-full bg-white/10 px-2 py-0.5 text-xs font-medium text-white/70">{items.length}</span>
+    </div>
+    <button
+      type="button"
+      class="rounded-full bg-white/10 p-2 text-white transition hover:bg-white/20"
+      aria-label="Close favorites"
+      on:click={onRequestClose}
+    >
+      <i class="fas fa-times" aria-hidden="true" />
+    </button>
+  </div>
+
+  <div class="max-h-[60vh] overflow-y-auto px-5 py-4 text-white/90">
+    {#if items.length === 0}
+      <p class="text-sm text-white/60">Your saved inspiration will appear here.</p>
+    {:else}
+      <ul class="space-y-3">
+        {#each items as item}
+          <li class="rounded-2xl bg-white/5 p-4 shadow-inner">
+            <p class="text-base text-white">{item.text}</p>
+            {#if item.author}
+              <p class="mt-1 text-sm text-white/70">— {item.author}</p>
+            {/if}
+
+            <div class="mt-3 flex items-center gap-2 text-xs">
+              <button
+                type="button"
+                class="inline-flex items-center gap-1 rounded-full bg-white/10 px-3 py-1 transition hover:bg-white/20"
+                on:click={() => onShare(item.id)}
+              >
+                <i class="fas fa-share-nodes" aria-hidden="true" /> Share
+              </button>
+              <button
+                type="button"
+                class="inline-flex items-center gap-1 rounded-full bg-white/10 px-3 py-1 transition hover:bg-rose-500/80 hover:text-white"
+                on:click={() => onRemove(item.id)}
+              >
+                <i class="fas fa-trash" aria-hidden="true" /> Remove
+              </button>
+            </div>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+
+  <div class="flex items-center justify-between border-t border-white/10 px-5 py-4 text-sm text-white/70">
+    <button
+      type="button"
+      class="rounded-full bg-white/10 px-4 py-2 font-medium transition hover:bg-white/20"
+      on:click={onClear}
+      disabled={items.length === 0}
+    >
+      Clear all
+    </button>
+    <span>{items.length} {items.length === 1 ? 'favorite' : 'favorites'}</span>
+  </div>
+</Modal>

--- a/src/app/panels/SettingsPanel.svelte
+++ b/src/app/panels/SettingsPanel.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import { bus, EVENTS } from '../../lib/bus';
+  import { store } from '../../lib/store';
+  import { RenderMode, type MatrixConfig } from '../../features/matrix/config';
+  import { updateMatrix } from '../../features/matrix/engine';
+  import Modal from '../components/Modal.svelte';
+
+  export let open = false;
+  export let onClose: () => void = () => {};
+
+  let matrixEnabled = true;
+  let beepEnabled = true;
+  let reducedMotion = store.get('matrix').reducedMotion;
+  let renderMode: RenderMode = store.get('matrix').renderMode;
+
+  function applyMatrixConfig(next: Partial<MatrixConfig>): void {
+    const current = store.get('matrix');
+    store.set('matrix', { ...current, ...next });
+    updateMatrix();
+  }
+
+  function toggleMatrix(): void {
+    matrixEnabled = !matrixEnabled;
+    bus.emit(EVENTS.MATRIX_TOGGLE, matrixEnabled);
+  }
+
+  function toggleBeep(): void {
+    beepEnabled = !beepEnabled;
+    bus.emit(EVENTS.BEEP_TOGGLE, beepEnabled);
+  }
+
+  function toggleReducedMotion(): void {
+    reducedMotion = !reducedMotion;
+    applyMatrixConfig({ reducedMotion });
+  }
+
+  function changeRenderMode(mode: RenderMode): void {
+    renderMode = mode;
+    applyMatrixConfig({ renderMode: mode });
+  }
+</script>
+
+<Modal open={open} on:close={onClose} labelledBy="settings-title">
+  <div class="flex items-center justify-between border-b border-white/10 px-5 py-4 text-white">
+    <h2 id="settings-title" class="text-sm font-semibold uppercase tracking-wide">Settings</h2>
+    <button
+      type="button"
+      class="rounded-full bg-white/10 p-2 text-white transition hover:bg-white/20"
+      aria-label="Close settings"
+      on:click={onClose}
+    >
+      <i class="fas fa-times" aria-hidden="true" />
+    </button>
+  </div>
+
+  <div class="space-y-6 px-5 py-4 text-sm text-white/80">
+    <section class="space-y-3">
+      <h3 class="text-xs font-semibold uppercase tracking-wide text-white/60">General</h3>
+      <label class="flex items-center justify-between gap-4 rounded-2xl bg-white/5 px-4 py-3">
+        <span>Visual effects</span>
+        <input type="checkbox" bind:checked={matrixEnabled} on:change={toggleMatrix} />
+      </label>
+      <label class="flex items-center justify-between gap-4 rounded-2xl bg-white/5 px-4 py-3">
+        <span>Sound chime before quotes</span>
+        <input type="checkbox" bind:checked={beepEnabled} on:change={toggleBeep} />
+      </label>
+    </section>
+
+    <section class="space-y-3">
+      <h3 class="text-xs font-semibold uppercase tracking-wide text-white/60">Matrix renderer</h3>
+      <label class="flex items-center justify-between gap-4 rounded-2xl bg-white/5 px-4 py-3">
+        <span>Reduced motion</span>
+        <input type="checkbox" bind:checked={reducedMotion} on:change={toggleReducedMotion} />
+      </label>
+      <div class="rounded-2xl bg-white/5 px-4 py-3">
+        <label for="matrix-mode" class="block text-xs uppercase tracking-wide text-white/60">Render mode</label>
+        <select
+          id="matrix-mode"
+          class="mt-2 w-full rounded-xl bg-slate-900/60 px-3 py-2 text-sm text-white"
+          bind:value={renderMode}
+          on:change={(event) => changeRenderMode((event.target as HTMLSelectElement).value as RenderMode)}
+        >
+          <option value={RenderMode.DOM}>DOM</option>
+          <option value={RenderMode.CANVAS}>Canvas</option>
+          <option value={RenderMode.HYBRID}>Hybrid</option>
+        </select>
+      </div>
+    </section>
+  </div>
+
+  <div class="border-t border-white/10 px-5 py-4 text-xs text-white/50">
+    Changes apply instantly and respect your reduced-motion preference.
+  </div>
+</Modal>

--- a/src/app/stores/favorites.ts
+++ b/src/app/stores/favorites.ts
@@ -1,0 +1,94 @@
+import { get, writable } from 'svelte/store';
+import { bus, EVENTS } from '../../lib/bus';
+import {
+  add,
+  all,
+  clear,
+  favoriteId,
+  remove,
+  type FavoriteItem,
+} from '../../features/favorites/store';
+import type { QuoteViewModel } from './quote';
+
+const store = writable<FavoriteItem[]>(all());
+
+function sync(): void {
+  store.set(all());
+}
+
+bus.on(EVENTS.FAV_CHANGED, sync);
+
+export const favorites = { subscribe: store.subscribe };
+
+function toFavoriteInput(quote: QuoteViewModel | null): FavoriteItem | null {
+  if (!quote) return null;
+  const text = typeof quote.text === 'string' ? quote.text.trim() : '';
+  if (!text) return null;
+  const author = typeof quote.author === 'string' && quote.author.trim() ? quote.author.trim() : null;
+  return {
+    id: favoriteId(text, author),
+    text,
+    author,
+  };
+}
+
+export function isFavorite(quote: QuoteViewModel | null): boolean {
+  if (!quote) return false;
+  const target = toFavoriteInput(quote);
+  if (!target) return false;
+  return get(store).some((item) => item.id === target.id);
+}
+
+export function toggleFavorite(quote: QuoteViewModel | null): void {
+  const target = toFavoriteInput(quote);
+  if (!target) return;
+  if (isFavorite(quote)) {
+    remove(target.id);
+  } else {
+    add({ text: target.text, author: target.author });
+  }
+}
+
+export function removeFavorite(id: string): void {
+  remove(id);
+}
+
+export function clearFavorites(): void {
+  clear();
+}
+
+export function openFavorites(opener?: HTMLElement | null): void {
+  bus.emit(EVENTS.FAV_OPEN, { opener: opener ?? null });
+}
+
+export function closeFavorites(): void {
+  bus.emit(EVENTS.FAV_CLOSE);
+}
+
+async function shareText(text: string): Promise<void> {
+  if (navigator.share) {
+    try {
+      await navigator.share({ text });
+      return;
+    } catch {
+      /* fall through to clipboard */
+    }
+  }
+
+  try {
+    await navigator.clipboard?.writeText(text);
+  } catch {
+    /* ignore clipboard failures */
+  }
+}
+
+export async function shareFavorite(item: FavoriteItem): Promise<void> {
+  const text = item.author ? `${item.text} — ${item.author}` : item.text;
+  await shareText(text);
+}
+
+export async function shareFavoriteById(id: string): Promise<void> {
+  const item = get(store).find((entry) => entry.id === id);
+  if (!item) return;
+  await shareFavorite(item);
+}

--- a/src/app/stores/quote.ts
+++ b/src/app/stores/quote.ts
@@ -1,0 +1,92 @@
+import { writable } from 'svelte/store';
+import { bus, EVENTS } from '../../lib/bus';
+
+export interface QuoteViewModel {
+  id?: string;
+  text: string;
+  author: string | null;
+  category?: string | null;
+  [key: string]: unknown;
+}
+
+type QuoteIntent = Record<string, unknown> | undefined;
+
+function toText(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (value == null) return '';
+  return String(value).trim();
+}
+
+function readLegacyQuote(): QuoteViewModel | null {
+  const textEl = document.getElementById('quote-text');
+  const authorEl = document.getElementById('quote-author');
+  const text = toText(textEl?.textContent);
+  if (!text) return null;
+  const rawAuthor = toText(authorEl?.textContent).replace(/^—\s*/, '');
+  const author = rawAuthor || null;
+  return { text, author };
+}
+
+function normalizeQuote(payload: unknown): QuoteViewModel | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const input = payload as Record<string, unknown>;
+  const text = toText(input.text ?? input.quote);
+  if (!text) return null;
+
+  const author = toText(input.author ?? input.a);
+  const category = toText(input.category ?? input.c);
+  const id = toText(input.id);
+
+  return {
+    ...input,
+    id: id || undefined,
+    text,
+    author: author || null,
+    category: category || null,
+  };
+}
+
+const initialQuote = readLegacyQuote();
+let currentValue: QuoteViewModel | null = initialQuote;
+const { subscribe, set } = writable<QuoteViewModel | null>(initialQuote);
+
+function commit(value: QuoteViewModel | null): void {
+  currentValue = value;
+  set(value);
+}
+
+const handleQuote = (payload: unknown) => {
+  const normalized = normalizeQuote(payload);
+  if (normalized) {
+    commit(normalized);
+  }
+};
+
+bus.on(EVENTS.QUOTE_GENERATED, handleQuote);
+
+let requestedInitial = false;
+
+function emitRequest(intent: QuoteIntent): void {
+  const base = intent && typeof intent === 'object' ? { ...intent } : {};
+  if (!('source' in (base as Record<string, unknown>))) {
+    (base as Record<string, unknown>).source = 'svelte:quote-store';
+  }
+  bus.emit(EVENTS.QUOTE_REQUEST, base);
+}
+
+export function requestNextQuote(intent?: QuoteIntent): void {
+  emitRequest(intent);
+}
+
+export function ensureInitialQuote(): void {
+  if (requestedInitial) return;
+  requestedInitial = true;
+  if (!currentValue) {
+    emitRequest({ reason: 'initial-render' });
+  }
+}
+
+export const currentQuote = { subscribe };

--- a/src/app/vite-env.d.ts
+++ b/src/app/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,7 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+const config = {
+  preprocess: vitePreprocess(),
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,11 @@
 {
+  "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
     "moduleResolution": "Node",
-    "esModuleInterop": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["vitest/globals"]
+    "types": ["svelte", "vitest/globals"],
+    "allowJs": true,
+    "checkJs": false
   },
-  "include": ["src"]
+  "include": ["src/**/*", "src/**/*.svelte"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [svelte()],
+});


### PR DESCRIPTION
## Summary
- add a Svelte-powered app shell with quote card, controls, header, favorites, and settings panels that integrate with the existing event bus
- create reusable Svelte stores for quotes and favorites plus a matrix wrapper so the new UI can drive current engines
- wire the static site to mount the Svelte app, hide legacy UI duplicates, and add the necessary Vite/Svelte tooling

## Testing
- npm run check (fails: existing TypeScript sources contain syntax errors that predate this change)
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca9f1b5004832bb22a5362ba150ca5