### PR TITLE
Add aura customization controls and glow component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1763,6 +1763,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -3528,6 +3541,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3835,13 +3861,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -4767,6 +4793,19 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/tailwindcss/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tailwindcss/node_modules/postcss-load-config": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
@@ -4882,19 +4921,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tinypool": {
@@ -5214,19 +5240,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vitefu": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz",
@@ -5318,19 +5331,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/src/app/AppShell.svelte
+++ b/src/app/AppShell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
+import AuraGlow from './components/AuraGlow.svelte';
 import MatrixLayer from './features/matrix/MatrixLayer.svelte';
 import ControlsBar from './components/ControlsBar.svelte';
 import HeaderBar from './components/HeaderBar.svelte';
@@ -36,6 +37,7 @@ export let navigateTo: (route: 'home' | 'about') => void = () => {};
   }
 </script>
 
+<AuraGlow />
 <MatrixLayer />
 
 <main class="relative z-[100] flex flex-col gap-8 py-14">

--- a/src/app/components/AuraGlow.svelte
+++ b/src/app/components/AuraGlow.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import {
+    AURA_LOOKUP,
+    DEFAULT_AURA,
+    DEFAULT_AURA_SETTINGS,
+    type AuraPaletteEntry,
+  } from '../config/aura';
+  import { settings } from '../stores/settings';
+
+  let gradient: AuraPaletteEntry['gradient'] = DEFAULT_AURA.gradient;
+  let size = DEFAULT_AURA_SETTINGS.size;
+
+  const unsubscribe = settings.subscribe((value) => {
+    const palette = AURA_LOOKUP.get(value.aura.colorKey) ?? DEFAULT_AURA;
+    gradient = palette.gradient;
+    size = value.aura.size;
+  });
+
+  onDestroy(() => {
+    unsubscribe();
+  });
+
+  $: auraSize = `${size}vmin`;
+</script>
+
+<div
+  class="aura-glow"
+  aria-hidden="true"
+  style={`--aura-gradient: ${gradient}; --aura-size: ${auraSize};`}
+>
+  <div class="aura-glow__halo"></div>
+</div>
+
+<style>
+  .aura-glow {
+    position: fixed;
+    inset: 0;
+    z-index: -5;
+    pointer-events: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: opacity 0.6s ease;
+  }
+
+  .aura-glow__halo {
+    width: var(--aura-size, 110vmin);
+    height: var(--aura-size, 110vmin);
+    background: var(--aura-gradient);
+    border-radius: 9999px;
+    filter: blur(120px);
+    opacity: 0.78;
+    transition:
+      background 0.6s ease,
+      width 0.6s ease,
+      height 0.6s ease,
+      opacity 0.6s ease;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .aura-glow,
+    .aura-glow__halo {
+      transition-duration: 0.01ms;
+      transition-delay: 0.01ms;
+    }
+  }
+</style>

--- a/src/app/config/aura.ts
+++ b/src/app/config/aura.ts
@@ -1,0 +1,59 @@
+export interface AuraPaletteEntry {
+  key: string;
+  label: string;
+  gradient: string;
+}
+
+export interface AuraSettings {
+  colorKey: string;
+  size: number;
+}
+
+export const AURA_SIZE_MIN = 60;
+export const AURA_SIZE_MAX = 160;
+export const AURA_SIZE_STEP = 5;
+export const DEFAULT_AURA_SIZE = 110;
+
+export const AURA_PALETTE: AuraPaletteEntry[] = [
+  {
+    key: 'celestial-dawn',
+    label: 'Celestial Dawn',
+    gradient:
+      'radial-gradient(circle at center, rgba(56, 189, 248, 0.65), rgba(129, 140, 248, 0.25) 45%, transparent 75%)',
+  },
+  {
+    key: 'aurora-mist',
+    label: 'Aurora Mist',
+    gradient:
+      'radial-gradient(circle at center, rgba(16, 185, 129, 0.6), rgba(6, 182, 212, 0.25) 45%, transparent 75%)',
+  },
+  {
+    key: 'ember-glow',
+    label: 'Ember Glow',
+    gradient:
+      'radial-gradient(circle at center, rgba(248, 113, 113, 0.55), rgba(251, 191, 36, 0.25) 50%, transparent 78%)',
+  },
+  {
+    key: 'violet-dream',
+    label: 'Violet Dream',
+    gradient:
+      'radial-gradient(circle at center, rgba(196, 181, 253, 0.6), rgba(99, 102, 241, 0.25) 50%, transparent 78%)',
+  },
+  {
+    key: 'midnight-tide',
+    label: 'Midnight Tide',
+    gradient:
+      'radial-gradient(circle at center, rgba(14, 165, 233, 0.6), rgba(37, 99, 235, 0.25) 45%, transparent 75%)',
+  },
+];
+
+export const DEFAULT_AURA = AURA_PALETTE[0];
+
+export const AURA_LOOKUP = new Map<string, AuraPaletteEntry>(
+  AURA_PALETTE.map((entry) => [entry.key, entry]),
+);
+
+export const DEFAULT_AURA_SETTINGS: AuraSettings = {
+  colorKey: DEFAULT_AURA.key,
+  size: DEFAULT_AURA_SIZE,
+};

--- a/src/app/features/matrix/MatrixLayer.svelte
+++ b/src/app/features/matrix/MatrixLayer.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import { initMatrix, teardownMatrix, updateMatrix } from '../../../features/matrix/engine';
   import { DEFAULTS } from '../../../features/matrix/config';
+  import { DEFAULT_AURA_SETTINGS } from '../../config/aura';
   import { settings, type AppSettingsState } from '../../stores/settings';
 
   let initialized = false;
@@ -10,6 +11,7 @@
     matrixEnabled: true,
     beepEnabled: false,
     matrix: DEFAULTS,
+    aura: { ...DEFAULT_AURA_SETTINGS },
   };
 
   function applyState(): void {

--- a/src/app/panels/SettingsPanel.svelte
+++ b/src/app/panels/SettingsPanel.svelte
@@ -4,7 +4,16 @@
   import { onDestroy } from 'svelte';
   import { RenderMode } from '../../features/matrix/config';
   import {
+    AURA_PALETTE,
+    AURA_SIZE_MAX,
+    AURA_SIZE_MIN,
+    AURA_SIZE_STEP,
+    DEFAULT_AURA_SETTINGS,
+  } from '../config/aura';
+  import {
     settings,
+    setAuraColor,
+    setAuraSize,
     setBeepEnabled,
     setMatrixEnabled,
     updateMatrixConfig,
@@ -18,12 +27,16 @@
   let beepEnabled = false;
   let reducedMotion = false;
   let renderMode: RenderMode = RenderMode.Canvas;
+  let auraColorKey = DEFAULT_AURA_SETTINGS.colorKey;
+  let auraSize = DEFAULT_AURA_SETTINGS.size;
 
   const unsubscribe = settings.subscribe((value) => {
     matrixEnabled = value.matrixEnabled;
     beepEnabled = value.beepEnabled;
     reducedMotion = value.matrix.reducedMotion;
     renderMode = value.matrix.renderMode;
+    auraColorKey = value.aura.colorKey;
+    auraSize = value.aura.size;
   });
 
   onDestroy(() => {
@@ -54,6 +67,15 @@
     const value = (select.value as RenderMode) || RenderMode.Canvas;
     updateMatrixConfig({ renderMode: value });
   }
+
+  function handleAuraSizeInput(event: Event): void {
+    const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
+    if (!input) return;
+    const next = Number.parseFloat(input.value);
+    if (Number.isFinite(next)) {
+      setAuraSize(next);
+    }
+  }
 </script>
 
 <Modal open={open} on:close={onClose} labelledBy="settings-title">
@@ -80,6 +102,50 @@
         <span>Sound chime before quotes</span>
         <input type="checkbox" checked={beepEnabled} on:change={handleBeepChange} />
       </label>
+    </section>
+
+    <section class="space-y-3">
+      <h3 class="text-xs font-semibold uppercase tracking-wide text-white/60">Aura glow</h3>
+      <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
+        {#each AURA_PALETTE as swatch (swatch.key)}
+          <button
+            type="button"
+            class={`group relative overflow-hidden rounded-2xl border bg-slate-900/40 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 ${
+              auraColorKey === swatch.key
+                ? 'border-white/70 ring-2 ring-white/70'
+                : 'border-white/10 hover:border-white/30'
+            }`}
+            style={`background-image: ${swatch.gradient};`}
+            aria-pressed={auraColorKey === swatch.key}
+            on:click={() => setAuraColor(swatch.key)}
+          >
+            <span
+              class="relative z-10 block px-3 py-4 text-center text-xs font-semibold uppercase tracking-wide text-white drop-shadow"
+            >
+              {swatch.label}
+            </span>
+            <span class="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-black/40"></span>
+          </button>
+        {/each}
+      </div>
+
+      <div class="rounded-2xl bg-white/5 px-4 py-3">
+        <div class="flex items-center justify-between text-xs uppercase tracking-wide text-white/60">
+          <label for="aura-size">Aura size</label>
+          <span class="font-semibold text-white/70">{Math.round(auraSize)}</span>
+        </div>
+        <input
+          id="aura-size"
+          type="range"
+          class="mt-3 w-full accent-white/80"
+          min={AURA_SIZE_MIN}
+          max={AURA_SIZE_MAX}
+          step={AURA_SIZE_STEP}
+          value={auraSize}
+          on:input={handleAuraSizeInput}
+        />
+        <p class="mt-2 text-[0.7rem] text-white/50">Fine-tune the glow radius around the interface.</p>
+      </div>
     </section>
 
     <section class="space-y-3">

--- a/src/app/stores/settings.ts
+++ b/src/app/stores/settings.ts
@@ -1,10 +1,19 @@
 import { writable } from 'svelte/store';
 import { DEFAULTS, type MatrixConfig } from '../../features/matrix/config';
+import {
+  AURA_LOOKUP,
+  AURA_SIZE_MAX,
+  AURA_SIZE_MIN,
+  DEFAULT_AURA,
+  DEFAULT_AURA_SETTINGS,
+  type AuraSettings,
+} from '../config/aura';
 
 export interface AppSettingsState {
   matrixEnabled: boolean;
   beepEnabled: boolean;
   matrix: MatrixConfig;
+  aura: AuraSettings;
 }
 
 const STORAGE_KEY = 'vibeme:settings:v1';
@@ -24,10 +33,15 @@ function resolveInitialState(): AppSettingsState {
     reducedMotion: resolveReducedMotion(DEFAULTS.reducedMotion),
   };
 
+  const baseAura: AuraSettings = {
+    ...DEFAULT_AURA_SETTINGS,
+  };
+
   const baseState: AppSettingsState = {
     matrixEnabled: true,
     beepEnabled: false,
     matrix: baseMatrix,
+    aura: baseAura,
   };
 
   if (typeof window === 'undefined') {
@@ -45,6 +59,20 @@ function resolveInitialState(): AppSettingsState {
       return baseState;
     }
 
+    const parsedAura =
+      parsed.aura && typeof parsed.aura === 'object'
+        ? (parsed.aura as Partial<AuraSettings>)
+        : null;
+
+    const persistedAuraKey =
+      parsedAura && typeof parsedAura.colorKey === 'string' ? parsedAura.colorKey : baseAura.colorKey;
+    const auraColorKey = AURA_LOOKUP.has(persistedAuraKey) ? persistedAuraKey : baseAura.colorKey;
+
+    const persistedAuraSize =
+      parsedAura && typeof parsedAura.size === 'number' && Number.isFinite(parsedAura.size)
+        ? clamp(parsedAura.size, AURA_SIZE_MIN, AURA_SIZE_MAX)
+        : baseAura.size;
+
     return {
       matrixEnabled:
         typeof parsed.matrixEnabled === 'boolean' ? parsed.matrixEnabled : baseState.matrixEnabled,
@@ -52,6 +80,10 @@ function resolveInitialState(): AppSettingsState {
       matrix: {
         ...baseMatrix,
         ...(parsed.matrix && typeof parsed.matrix === 'object' ? parsed.matrix : {}),
+      },
+      aura: {
+        colorKey: auraColorKey,
+        size: persistedAuraSize,
       },
     };
   } catch (error) {
@@ -61,6 +93,10 @@ function resolveInitialState(): AppSettingsState {
 }
 
 const store = writable<AppSettingsState>(resolveInitialState());
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
 
 if (typeof window !== 'undefined') {
   store.subscribe((value) => {
@@ -100,6 +136,45 @@ export function updateMatrixConfig(patch: Partial<MatrixConfig>): void {
       ...patch,
     },
   }));
+}
+
+export function setAuraColor(colorKey: string): void {
+  store.update((state) => {
+    const nextKey = AURA_LOOKUP.has(colorKey) ? colorKey : state.aura.colorKey ?? DEFAULT_AURA.key;
+    if (state.aura.colorKey === nextKey) {
+      return state;
+    }
+
+    return {
+      ...state,
+      aura: {
+        ...state.aura,
+        colorKey: nextKey,
+      },
+    };
+  });
+}
+
+export function setAuraSize(size: number): void {
+  if (!Number.isFinite(size)) {
+    return;
+  }
+
+  const clamped = clamp(size, AURA_SIZE_MIN, AURA_SIZE_MAX);
+
+  store.update((state) => {
+    if (state.aura.size === clamped) {
+      return state;
+    }
+
+    return {
+      ...state,
+      aura: {
+        ...state.aura,
+        size: clamped,
+      },
+    };
+  });
 }
 
 export const __testing__ = { resolveInitialState };


### PR DESCRIPTION
## Summary
- introduce an aura palette configuration with defaults and ranges and extend the settings store to persist aura selections
- wire the aura state into the UI by rendering the reactive AuraGlow background and adding palette + size controls to the settings panel
- keep matrix integration aligned with the extended settings shape so background effects respond to user choices

## Testing
- npm run lint
- npm run check
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68cbf59e43f4832bae664149f4074940