### PR TITLE
Handle reduced motion and touch for AuraGlow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1763,6 +1763,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -3528,6 +3541,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3835,13 +3861,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -4767,6 +4793,19 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/tailwindcss/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tailwindcss/node_modules/postcss-load-config": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
@@ -4882,19 +4921,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tinypool": {
@@ -5214,19 +5240,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vitefu": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz",
@@ -5318,19 +5331,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/src/app/features/matrix/AuraGlow.svelte
+++ b/src/app/features/matrix/AuraGlow.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { settings, type AppSettingsState } from '../../stores/settings';
+
+  const POINTER_QUERY = '(pointer: coarse)';
+  const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+  let auraNode: HTMLDivElement | null = null;
+  let unsubscribe: () => void = () => {};
+  let pointerMedia: MediaQueryList | null = null;
+  let reducedMedia: MediaQueryList | null = null;
+  let pointerListener: ((event: MediaQueryListEvent) => void) | null = null;
+  let reducedListener: ((event: MediaQueryListEvent) => void) | null = null;
+
+  let pointerMoveAttached = false;
+  let frameScheduled = false;
+  let rafId = 0;
+  let latestX = 0;
+  let latestY = 0;
+  let hasPointerData = false;
+
+  let reducedMotionFromSettings = false;
+  let reducedMotionFromSystem = false;
+  let pointerIsCoarse = false;
+
+  function reducedMotionEnabled(): boolean {
+    return reducedMotionFromSettings || reducedMotionFromSystem;
+  }
+
+  function setStaticGlow(): void {
+    if (!auraNode) return;
+    auraNode.dataset.state = 'static';
+    auraNode.style.background =
+      'radial-gradient(circle at 70% 20%, var(--glow-color), transparent 60%)';
+  }
+
+  function setDefaultDynamicGlow(): void {
+    if (typeof window === 'undefined') return;
+    hasPointerData = false;
+    latestX = window.innerWidth * 0.65;
+    latestY = window.innerHeight * 0.35;
+    if (!auraNode) return;
+    auraNode.style.background =
+      `radial-gradient(circle at ${latestX}px ${latestY}px, var(--glow-color), transparent 60%)`;
+  }
+
+  function updateDynamicGlow(): void {
+    if (!auraNode) return;
+    auraNode.dataset.state = 'dynamic';
+    auraNode.style.background =
+      `radial-gradient(circle at ${latestX}px ${latestY}px, var(--glow-color), transparent 60%)`;
+  }
+
+  function detachPointerListener(): void {
+    if (pointerMoveAttached) {
+      window.removeEventListener('pointermove', handlePointerMove);
+      pointerMoveAttached = false;
+    }
+    if (rafId) {
+      cancelAnimationFrame(rafId);
+      rafId = 0;
+    }
+    frameScheduled = false;
+  }
+
+  function attachPointerListener(): void {
+    if (pointerMoveAttached || typeof window === 'undefined') return;
+    window.addEventListener('pointermove', handlePointerMove, { passive: true });
+    pointerMoveAttached = true;
+  }
+
+  function scheduleUpdate(): void {
+    if (frameScheduled) return;
+    frameScheduled = true;
+    rafId = requestAnimationFrame(() => {
+      frameScheduled = false;
+      if (reducedMotionEnabled() || pointerIsCoarse) {
+        return;
+      }
+      updateDynamicGlow();
+    });
+  }
+
+  function handlePointerMove(event: PointerEvent): void {
+    if (reducedMotionEnabled() || pointerIsCoarse) {
+      return;
+    }
+    hasPointerData = true;
+    latestX = event.clientX;
+    latestY = event.clientY;
+    scheduleUpdate();
+  }
+
+  function applyState(): void {
+    if (!auraNode) return;
+
+    if (reducedMotionEnabled()) {
+      auraNode.dataset.state = 'hidden';
+      auraNode.style.opacity = '0';
+      auraNode.style.background = 'none';
+      detachPointerListener();
+      return;
+    }
+
+    auraNode.style.opacity = pointerIsCoarse ? '0.45' : '0.8';
+
+    if (pointerIsCoarse) {
+      detachPointerListener();
+      setStaticGlow();
+      return;
+    }
+
+    if (!hasPointerData) {
+      setDefaultDynamicGlow();
+    }
+    attachPointerListener();
+    updateDynamicGlow();
+  }
+
+  function cleanup(): void {
+    detachPointerListener();
+    if (pointerMedia && pointerListener) {
+      pointerMedia.removeEventListener('change', pointerListener);
+    }
+    if (reducedMedia && reducedListener) {
+      reducedMedia.removeEventListener('change', reducedListener);
+    }
+    unsubscribe();
+    auraNode?.remove();
+    auraNode = null;
+  }
+
+  onMount(() => {
+    if (typeof document === 'undefined' || typeof window === 'undefined') {
+      return;
+    }
+
+    auraNode = document.createElement('div');
+    auraNode.className = 'aura-glow-node';
+    auraNode.dataset.state = 'hidden';
+    document.body.appendChild(auraNode);
+
+    unsubscribe = settings.subscribe((value: AppSettingsState) => {
+      reducedMotionFromSettings = value.matrix.reducedMotion;
+      applyState();
+    });
+
+    if (typeof window.matchMedia === 'function') {
+      try {
+        pointerMedia = window.matchMedia(POINTER_QUERY);
+        pointerIsCoarse = pointerMedia.matches;
+        pointerListener = (event: MediaQueryListEvent) => {
+          pointerIsCoarse = event.matches;
+          applyState();
+        };
+        pointerMedia.addEventListener('change', pointerListener);
+      } catch {
+        pointerMedia = null;
+      }
+
+      try {
+        reducedMedia = window.matchMedia(REDUCED_MOTION_QUERY);
+        reducedMotionFromSystem = reducedMedia.matches;
+        reducedListener = (event: MediaQueryListEvent) => {
+          reducedMotionFromSystem = event.matches;
+          applyState();
+        };
+        reducedMedia.addEventListener('change', reducedListener);
+      } catch {
+        reducedMedia = null;
+      }
+    }
+
+    setDefaultDynamicGlow();
+    applyState();
+  });
+
+  onDestroy(cleanup);
+</script>
+
+<style>
+  :global(.aura-glow-node) {
+    position: fixed;
+    inset: 0;
+    z-index: -5;
+    pointer-events: none;
+    transition: opacity 250ms ease;
+    filter: blur(120px);
+    opacity: 0;
+  }
+
+  :global(.aura-glow-node[data-state='dynamic']) {
+    opacity: 0.8;
+  }
+
+  :global(.aura-glow-node[data-state='static']) {
+    opacity: 0.45;
+  }
+</style>

--- a/src/app/features/matrix/MatrixLayer.svelte
+++ b/src/app/features/matrix/MatrixLayer.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import { initMatrix, teardownMatrix, updateMatrix } from '../../../features/matrix/engine';
-  import { DEFAULTS } from '../../../features/matrix/config';
+  import { DEFAULTS, RenderMode } from '../../../features/matrix/config';
   import { settings, type AppSettingsState } from '../../stores/settings';
+  import AuraGlow from './AuraGlow.svelte';
 
   let initialized = false;
   let mounted = false;
@@ -17,7 +18,9 @@
       return;
     }
 
-    if (state.matrixEnabled) {
+    const wantsCanvas = state.matrixEnabled && state.matrix.renderMode === RenderMode.Canvas;
+
+    if (wantsCanvas) {
       if (!initialized) {
         initMatrix(state.matrix);
         initialized = true;
@@ -49,3 +52,7 @@
     unsubscribe();
   });
 </script>
+
+{#if state.matrixEnabled && state.matrix.renderMode === RenderMode.Minimal}
+  <AuraGlow />
+{/if}


### PR DESCRIPTION
## Summary
- add an AuraGlow overlay that respects reduced motion preferences and coarse pointers
- throttle pointer tracking with requestAnimationFrame and clean up all listeners/nodes
- show the AuraGlow only for the minimal matrix mode while skipping the canvas renderer

## Testing
- npm run lint
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbf5a56178832b959d550b8f611998