### PR TITLE
Add persistent theme store and toggle component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1763,6 +1763,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -3528,6 +3541,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3835,13 +3861,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -4767,6 +4793,19 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/tailwindcss/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tailwindcss/node_modules/postcss-load-config": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
@@ -4882,19 +4921,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tinypool": {
@@ -5214,19 +5240,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vitefu": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz",
@@ -5318,19 +5331,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/src/app/components/HeaderBar.svelte
+++ b/src/app/components/HeaderBar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { FontAwesomeIcon as Fa } from '@fortawesome/svelte-fontawesome';
-  import { faBookmark, faGear, faPalette } from '@fortawesome/free-solid-svg-icons';
-  import { nextTheme } from '../../features/theme';
+  import { faBookmark, faGear } from '@fortawesome/free-solid-svg-icons';
+  import ThemeToggle from './ThemeToggle.svelte';
   import { openFavorites } from '../stores/favorites';
   import type { QuoteViewModel } from '../stores/quote';
 
@@ -9,10 +9,6 @@
   export let onOpenSettings: () => void = () => {};
 
   let favoritesButton: HTMLButtonElement | null = null;
-
-  function handleTheme(): void {
-    nextTheme();
-  }
 
   function handleFavorites(): void {
     openFavorites(favoritesButton ?? undefined);
@@ -28,14 +24,7 @@
   </div>
 
   <div class="flex items-center gap-2">
-    <button
-      type="button"
-      class="rounded-full bg-white/10 p-2 text-white transition hover:bg-white/20"
-      aria-label="Shuffle theme"
-      on:click={handleTheme}
-    >
-      <Fa icon={faPalette} class="h-4 w-4" />
-    </button>
+    <ThemeToggle />
 
     <button
       type="button"

--- a/src/app/components/ThemeToggle.svelte
+++ b/src/app/components/ThemeToggle.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { currentTheme, setThemeByKey, themes } from '../../features/theme';
+
+  export type ThemeToggleSize = 'md' | 'sm';
+
+  export let size: ThemeToggleSize = 'md';
+  export let className = '';
+
+  const containerBase =
+    'inline-flex items-center gap-1 rounded-full bg-white/10 p-1 text-white transition hover:bg-white/15 focus-within:bg-white/15';
+  const buttonBase =
+    'rounded-full font-semibold capitalize transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white';
+  const activeClasses = 'bg-white/25 text-white shadow-sm';
+  const inactiveClasses = 'text-white/70 hover:bg-white/10 hover:text-white';
+  const sizeClasses = {
+    md: 'px-3 py-1.5 text-xs',
+    sm: 'px-2.5 py-1 text-[0.65rem]',
+  } as const;
+
+  function formatLabel(key: string): string {
+    return key
+      .split('-')
+      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join(' ');
+  }
+
+  function handleSelect(key: string): void {
+    if ($currentTheme.key === key) return;
+    setThemeByKey(key);
+  }
+
+  $: containerClasses = [containerBase, size === 'sm' ? 'text-[0.7rem]' : 'text-xs', className]
+    .filter(Boolean)
+    .join(' ');
+</script>
+
+<div class={containerClasses} role="group" aria-label="Select theme">
+  {#each themes as theme (theme.key)}
+    <button
+      type="button"
+      class={`${buttonBase} ${sizeClasses[size]} ${
+        theme.key === $currentTheme.key ? activeClasses : inactiveClasses
+      }`}
+      aria-pressed={theme.key === $currentTheme.key}
+      aria-label={`Activate ${formatLabel(theme.key)} theme`}
+      title={`${formatLabel(theme.key)} theme`}
+      on:click={() => handleSelect(theme.key)}
+    >
+      {formatLabel(theme.key)}
+    </button>
+  {/each}
+</div>

--- a/src/app/panels/SettingsPanel.svelte
+++ b/src/app/panels/SettingsPanel.svelte
@@ -10,6 +10,7 @@
     updateMatrixConfig,
   } from '../stores/settings';
   import Modal from '../components/Modal.svelte';
+  import ThemeToggle from '../components/ThemeToggle.svelte';
 
   export let open = false;
   export let onClose: () => void = () => {};
@@ -72,6 +73,13 @@
   <div class="space-y-6 px-5 py-4 text-sm text-white/80">
     <section class="space-y-3">
       <h3 class="text-xs font-semibold uppercase tracking-wide text-white/60">General</h3>
+      <div class="flex flex-wrap items-center justify-between gap-4 rounded-2xl bg-white/5 px-4 py-3">
+        <div>
+          <span class="text-sm text-white">Theme</span>
+          <p class="text-xs text-white/50">Choose your vibe palette</p>
+        </div>
+        <ThemeToggle size="sm" />
+      </div>
       <label class="flex items-center justify-between gap-4 rounded-2xl bg-white/5 px-4 py-3">
         <span>Visual effects</span>
         <input type="checkbox" checked={matrixEnabled} on:change={handleMatrixChange} />

--- a/src/features/theme/index.ts
+++ b/src/features/theme/index.ts
@@ -1,3 +1,5 @@
+import { writable, type Readable } from 'svelte/store';
+
 export interface Theme {
   key: string;
   gradient1: string;
@@ -5,6 +7,8 @@ export interface Theme {
   gradient3: string;
   glow: string;
 }
+
+const STORAGE_KEY = 'vibeme.theme';
 
 const DEFAULT_THEME: Theme = {
   key: 'synthwave',
@@ -32,9 +36,48 @@ export const themes: Theme[] = [
   },
 ];
 
-export let current: Theme = DEFAULT_THEME;
+function readStoredThemeKey(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function getThemeByKey(key: string): Theme | undefined {
+  return themes.find((item) => item.key === key);
+}
+
+function loadInitialTheme(): Theme {
+  const storedKey = readStoredThemeKey();
+  if (storedKey) {
+    const storedTheme = getThemeByKey(storedKey);
+    if (storedTheme) {
+      return storedTheme;
+    }
+  }
+  return DEFAULT_THEME;
+}
+
+let currentThemeValue: Theme = loadInitialTheme();
+
+const internalThemeStore = writable<Theme>(currentThemeValue);
+export const currentTheme: Readable<Theme> = {
+  subscribe: internalThemeStore.subscribe,
+};
+
+function persistThemeKey(key: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, key);
+  } catch {
+    /* ignore storage failures */
+  }
+}
 
 function updateDocument(theme: Theme): void {
+  if (typeof document === 'undefined') return;
   const root = document.documentElement;
   root.style.setProperty('--gradient-1', theme.gradient1);
   root.style.setProperty('--gradient-2', theme.gradient2);
@@ -43,27 +86,44 @@ function updateDocument(theme: Theme): void {
   document.body.dataset.theme = theme.key;
 }
 
-export function applyTheme(theme: Theme): void {
-  current = theme;
-  updateDocument(theme);
+export function getCurrentTheme(): Theme {
+  return currentThemeValue;
 }
 
-export function nextTheme(): Theme {
-  const index = themes.findIndex((item) => item.key === current.key);
-  const next = themes[(index + 1) % themes.length];
-  applyTheme(next);
-  return next;
+export function getCurrentThemeKey(): string {
+  return currentThemeValue.key;
+}
+
+export function applyTheme(theme: Theme, options: { persist?: boolean } = {}): Theme {
+  const { persist = true } = options;
+  currentThemeValue = theme;
+  internalThemeStore.set(theme);
+  if (persist) {
+    persistThemeKey(theme.key);
+  }
+  updateDocument(theme);
+  return theme;
+}
+
+export function setTheme(theme: Theme): Theme {
+  return applyTheme(theme);
 }
 
 export function setThemeByKey(key: string): Theme | undefined {
-  const theme = themes.find((item) => item.key === key);
+  const theme = getThemeByKey(key);
   if (theme) {
     applyTheme(theme);
-    return theme;
   }
-  return undefined;
+  return theme;
 }
 
-if (typeof window !== 'undefined') {
-  updateDocument(current);
+export function nextTheme(): Theme {
+  const currentKey = getCurrentThemeKey();
+  const index = themes.findIndex((item) => item.key === currentKey);
+  const next = index >= 0 ? themes[(index + 1) % themes.length] : themes[0];
+  return applyTheme(next);
+}
+
+if (typeof document !== 'undefined') {
+  updateDocument(currentThemeValue);
 }

--- a/src/features/theme/theme.test.ts
+++ b/src/features/theme/theme.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { applyTheme, nextTheme, setThemeByKey, current, themes } from './index';
+import { get } from 'svelte/store';
+import {
+  applyTheme,
+  currentTheme,
+  getCurrentTheme,
+  nextTheme,
+  setThemeByKey,
+  themes,
+} from './index';
 
 describe('theme', () => {
   beforeEach(() => {
-    // reset to first theme before each test
     setThemeByKey(themes[0].key);
   });
 
-  it('applyTheme updates current theme', () => {
+  it('applyTheme updates current theme and store', () => {
     const theme = {
       key: 'test',
       gradient1: '#111111',
@@ -15,39 +22,40 @@ describe('theme', () => {
       gradient3: '#333333',
       glow: '#ffffff',
     };
-    applyTheme(theme);
-    expect(current).toBe(theme);
+    applyTheme(theme, { persist: false });
+    expect(getCurrentTheme()).toBe(theme);
+    expect(get(currentTheme)).toBe(theme);
   });
 
   it('nextTheme selects next theme and updates current', () => {
-    const first = current;
+    const first = getCurrentTheme();
     const second = nextTheme();
-    expect(current).toBe(second);
-    expect(current).not.toBe(first);
+    expect(getCurrentTheme()).toBe(second);
+    expect(getCurrentTheme()).not.toBe(first);
 
     const third = nextTheme();
-    expect(current).toBe(third);
-    expect(current).not.toBe(first);
+    expect(getCurrentTheme()).toBe(third);
+    expect(getCurrentTheme()).not.toBe(first);
 
-    // cycle back
     const looped = nextTheme();
-    expect(current).toBe(looped);
-    expect(current).toBe(first);
+    expect(getCurrentTheme()).toBe(looped);
+    expect(getCurrentTheme()).toBe(first);
   });
 
   it('setThemeByKey selects theme and updates current', () => {
     const target = themes[1];
     setThemeByKey(target.key);
-    expect(current).toBe(target);
+    expect(getCurrentTheme()).toBe(target);
+    expect(get(currentTheme)).toBe(target);
   });
 
-  it('allows selecting next theme via helper', () => {
-    const first = current;
+  it('resets to a specific theme after cycling', () => {
+    const first = getCurrentTheme();
     const next = nextTheme();
-    expect(current).toBe(next);
-    expect(current).not.toBe(first);
+    expect(getCurrentTheme()).toBe(next);
+    expect(getCurrentTheme()).not.toBe(first);
 
     setThemeByKey(first.key);
-    expect(current).toBe(first);
+    expect(getCurrentTheme()).toBe(first);
   });
 });


### PR DESCRIPTION
## Summary
- persist the active theme using a readable Svelte store with localStorage support
- add a reusable ThemeToggle control and surface it in the header and settings panel
- refresh theme unit tests to exercise the new APIs

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbf5a92478832b96f8238d7898bac8