### PR TITLE
Refine aura glow interaction and pointer behavior

### DIFF
--- a/src/app/components/AuraGlow.svelte
+++ b/src/app/components/AuraGlow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import {
     AURA_LOOKUP,
     DEFAULT_AURA,
@@ -10,26 +10,157 @@
 
   let gradient: AuraPaletteEntry['gradient'] = DEFAULT_AURA.gradient;
   let size = DEFAULT_AURA_SETTINGS.size;
+  let reducedMotion = false;
+
+  let auraHalo: HTMLDivElement | null = null;
+  let mounted = false;
+  let pointerTracking = false;
+  let isCoarsePointer = false;
+  let pointerFrame: number | null = null;
+  let pendingPointer: { x: number; y: number } | null = null;
+  let removePointerPreferenceListener: (() => void) | null = null;
 
   const unsubscribe = settings.subscribe((value) => {
     const palette = AURA_LOOKUP.get(value.aura.colorKey) ?? DEFAULT_AURA;
     gradient = palette.gradient;
     size = value.aura.size;
+
+    const nextReducedMotion = value.matrix.reducedMotion;
+    const motionChanged = nextReducedMotion !== reducedMotion;
+    reducedMotion = nextReducedMotion;
+
+    if (motionChanged && mounted) {
+      evaluatePointerTracking();
+    }
+  });
+
+  function resetPointerPosition(): void {
+    if (!auraHalo) return;
+    auraHalo.style.setProperty('--pointer-x', '50vw');
+    auraHalo.style.setProperty('--pointer-y', '50vh');
+  }
+
+  function applyPendingPointer(): void {
+    pointerFrame = null;
+    if (!pendingPointer || !auraHalo) return;
+
+    const { x, y } = pendingPointer;
+    auraHalo.style.setProperty('--pointer-x', `${x}px`);
+    auraHalo.style.setProperty('--pointer-y', `${y}px`);
+  }
+
+  function handlePointerMove(event: PointerEvent): void {
+    if (!pointerTracking || !event.isPrimary || event.pointerType === 'touch') {
+      return;
+    }
+
+    pendingPointer = { x: event.clientX, y: event.clientY };
+    if (pointerFrame === null) {
+      pointerFrame = requestAnimationFrame(applyPendingPointer);
+    }
+  }
+
+  function startPointerTracking(): void {
+    if (pointerTracking || typeof window === 'undefined') {
+      return;
+    }
+
+    pointerTracking = true;
+    window.addEventListener('pointermove', handlePointerMove, { passive: true });
+  }
+
+  function stopPointerTracking({ reset = true }: { reset?: boolean } = {}): void {
+    if (!pointerTracking || typeof window === 'undefined') {
+      pointerTracking = false;
+      return;
+    }
+
+    window.removeEventListener('pointermove', handlePointerMove);
+    pointerTracking = false;
+
+    if (pointerFrame !== null) {
+      cancelAnimationFrame(pointerFrame);
+      pointerFrame = null;
+    }
+
+    pendingPointer = null;
+
+    if (reset) {
+      resetPointerPosition();
+    }
+  }
+
+  function evaluatePointerTracking(): void {
+    if (!mounted) return;
+
+    const shouldTrack = !reducedMotion && !isCoarsePointer;
+    if (shouldTrack) {
+      startPointerTracking();
+    } else {
+      stopPointerTracking({ reset: true });
+    }
+  }
+
+  function setupPointerPreferenceListener(): void {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const query = window.matchMedia('(pointer: coarse)');
+    isCoarsePointer = query.matches;
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      isCoarsePointer = event.matches;
+      evaluatePointerTracking();
+    };
+
+    if (typeof query.addEventListener === 'function') {
+      query.addEventListener('change', handleChange);
+      removePointerPreferenceListener = () => {
+        query.removeEventListener('change', handleChange);
+      };
+    } else if (typeof query.addListener === 'function') {
+      query.addListener(handleChange);
+      removePointerPreferenceListener = () => {
+        query.removeListener(handleChange);
+      };
+    }
+  }
+
+  onMount(() => {
+    mounted = true;
+    resetPointerPosition();
+    setupPointerPreferenceListener();
+    evaluatePointerTracking();
+
+    return () => {
+      stopPointerTracking({ reset: false });
+      if (removePointerPreferenceListener) {
+        removePointerPreferenceListener();
+        removePointerPreferenceListener = null;
+      }
+    };
   });
 
   onDestroy(() => {
     unsubscribe();
+    stopPointerTracking({ reset: false });
+    if (removePointerPreferenceListener) {
+      removePointerPreferenceListener();
+      removePointerPreferenceListener = null;
+    }
   });
 
   $: auraSize = `${size}vmin`;
+  $: auraOpacity = reducedMotion ? 0.42 : 0.78;
 </script>
 
 <div
   class="aura-glow"
   aria-hidden="true"
-  style={`--aura-gradient: ${gradient}; --aura-size: ${auraSize};`}
+  style={`--aura-gradient: ${gradient}; --aura-size: ${auraSize}; --aura-opacity: ${auraOpacity};`}
 >
-  <div class="aura-glow__halo"></div>
+  <div class="aura-glow__halo" bind:this={auraHalo}></div>
 </div>
 
 <style>
@@ -50,12 +181,19 @@
     background: var(--aura-gradient);
     border-radius: 9999px;
     filter: blur(120px);
-    opacity: 0.78;
+    opacity: var(--aura-opacity, 0.78);
+    transform: translate3d(
+      calc(var(--pointer-x, 50vw) - 50%),
+      calc(var(--pointer-y, 50vh) - 50%),
+      0
+    );
+    will-change: transform;
     transition:
       background 0.6s ease,
       width 0.6s ease,
       height 0.6s ease,
-      opacity 0.6s ease;
+      opacity 0.6s ease,
+      transform 0.45s ease;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/app/components/ThemeToggle.svelte
+++ b/src/app/components/ThemeToggle.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { currentTheme, setThemeByKey, themes } from '../../features/theme';
 
-  export type ThemeToggleSize = 'md' | 'sm';
+  type ThemeToggleSize = 'md' | 'sm';
 
   export let size: ThemeToggleSize = 'md';
   export let className = '';


### PR DESCRIPTION
## Summary
- make the aura glow track primary pointer movement with throttling while falling back gracefully when reduced motion is requested or only coarse pointers are available
- wire aura opacity and sizing to settings updates using CSS variables and reset logic to keep the glow centered when tracking is disabled
- resolve the lingering svelte-check complaint by keeping ThemeToggle's size type local to the component

## Testing
- npm run lint
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbf22d9798832b9105fa9744e314bc