### PR TITLE
Add quote autoplay and speech settings

### DIFF
--- a/src/app/AppShell.svelte
+++ b/src/app/AppShell.svelte
@@ -7,25 +7,143 @@ import HeaderBar from './components/HeaderBar.svelte';
 import QuoteCard from './components/QuoteCard.svelte';
 import FavoritesPanel from './panels/FavoritesPanel.svelte';
 import SettingsPanel from './panels/SettingsPanel.svelte';
-import { currentQuote, ensureInitialQuote, type QuoteViewModel } from './stores/quote';
+import { currentQuote, ensureInitialQuote, requestNextQuote, type QuoteViewModel } from './stores/quote';
+import { settings, setSpeechEnabled } from './stores/settings';
 
   let quote: QuoteViewModel | null = null;
 let settingsOpen = false;
+let autoAdvanceEnabled = false;
+let autoAdvanceInterval = 8;
+let speechEnabled = false;
+let mounted = false;
+let speechSupported = false;
+let lastSpeechEnabled = false;
+let autoAdvanceTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearAutoAdvanceTimer(): void {
+  if (autoAdvanceTimer) {
+    clearTimeout(autoAdvanceTimer);
+    autoAdvanceTimer = null;
+  }
+}
+
+function cancelSpeech(): void {
+  if (!speechSupported || typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.speechSynthesis?.cancel();
+  } catch {
+    /* ignore speech cancellation failures */
+  }
+}
+
+function speakQuote(value: QuoteViewModel | null): void {
+  if (!speechSupported || !speechEnabled || !value?.text?.trim() || typeof window === 'undefined') {
+    return;
+  }
+
+  const text = value.text.trim();
+  const author = value.author?.trim();
+  const payload = author ? `${text} — ${author}` : text;
+
+  cancelSpeech();
+
+  try {
+    const utterance = new SpeechSynthesisUtterance(payload);
+    window.speechSynthesis?.speak(utterance);
+  } catch {
+    /* ignore speech synthesis failures */
+  }
+}
+
+function scheduleAutoAdvance(): void {
+  if (!mounted || !autoAdvanceEnabled) {
+    return;
+  }
+
+  clearAutoAdvanceTimer();
+
+  if (!quote?.text?.trim()) {
+    return;
+  }
+
+  const delay = Math.max(5, Math.min(60, autoAdvanceInterval)) * 1000;
+
+  autoAdvanceTimer = setTimeout(() => {
+    autoAdvanceTimer = null;
+    requestNextQuote({ reason: 'auto-advance' });
+  }, delay);
+}
 
 export let navigateTo: (route: 'home' | 'about') => void = () => {};
 
-  const unsubscribe = currentQuote.subscribe((value) => {
+  const unsubscribeQuote = currentQuote.subscribe((value) => {
     quote = value;
+
+    if (!mounted) {
+      return;
+    }
+
+    scheduleAutoAdvance();
+
+    if (speechEnabled) {
+      speakQuote(value);
+    }
+  });
+
+  const unsubscribeSettings = settings.subscribe((value) => {
+    autoAdvanceEnabled = value.autoAdvanceEnabled;
+    autoAdvanceInterval = value.autoAdvanceInterval;
+    speechEnabled = value.speechEnabled;
+
+    if (!mounted) {
+      lastSpeechEnabled = speechEnabled;
+      return;
+    }
+
+    if (!speechEnabled && lastSpeechEnabled) {
+      cancelSpeech();
+    } else if (speechEnabled && !lastSpeechEnabled && quote) {
+      speakQuote(quote);
+    }
+
+    lastSpeechEnabled = speechEnabled;
+
+    if (!autoAdvanceEnabled) {
+      clearAutoAdvanceTimer();
+    } else {
+      scheduleAutoAdvance();
+    }
   });
 
   onMount(() => {
     document.body.classList.add('has-svelte-app');
+    mounted = true;
+    speechSupported =
+      typeof window !== 'undefined' &&
+      typeof window.speechSynthesis !== 'undefined' &&
+      typeof SpeechSynthesisUtterance !== 'undefined';
+    if (!speechSupported) {
+      if (speechEnabled) {
+        setSpeechEnabled(false);
+      }
+      speechEnabled = false;
+    } else if (speechEnabled && quote) {
+      speakQuote(quote);
+    }
     ensureInitialQuote();
+    scheduleAutoAdvance();
   });
 
   onDestroy(() => {
     document.body.classList.remove('has-svelte-app');
-    unsubscribe();
+    mounted = false;
+    clearAutoAdvanceTimer();
+    cancelSpeech();
+    unsubscribeQuote();
+    unsubscribeSettings();
   });
 
   function openSettings(): void {

--- a/src/app/components/ThemeToggle.svelte
+++ b/src/app/components/ThemeToggle.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { currentTheme, setThemeByKey, themes } from '../../features/theme';
 
-  export type ThemeToggleSize = 'md' | 'sm';
+  type ThemeToggleSize = 'md' | 'sm';
 
   export let size: ThemeToggleSize = 'md';
   export let className = '';

--- a/src/app/features/matrix/MatrixLayer.svelte
+++ b/src/app/features/matrix/MatrixLayer.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
+  import { DEFAULTS, RenderMode } from '../../../features/matrix/config';
   import { initMatrix, teardownMatrix, updateMatrix } from '../../../features/matrix/engine';
- 
+  import { DEFAULT_AURA_SETTINGS } from '../../config/aura';
   import { settings, type AppSettingsState } from '../../stores/settings';
   import AuraGlow from './AuraGlow.svelte';
 
@@ -10,6 +11,9 @@
   let state: AppSettingsState = {
     matrixEnabled: true,
     beepEnabled: false,
+    speechEnabled: false,
+    autoAdvanceEnabled: false,
+    autoAdvanceInterval: 8,
     matrix: DEFAULTS,
     aura: { ...DEFAULT_AURA_SETTINGS },
   };

--- a/src/app/panels/SettingsPanel.svelte
+++ b/src/app/panels/SettingsPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { FontAwesomeIcon as Fa } from '@fortawesome/svelte-fontawesome';
   import { faTimes } from '@fortawesome/free-solid-svg-icons';
-  import { onDestroy } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import { RenderMode } from '../../features/matrix/config';
   import {
     AURA_PALETTE,
@@ -14,8 +14,11 @@
     settings,
     setAuraColor,
     setAuraSize,
+    setAutoAdvanceEnabled,
+    setAutoAdvanceInterval,
     setBeepEnabled,
     setMatrixEnabled,
+    setSpeechEnabled,
     updateMatrixConfig,
   } from '../stores/settings';
   import Modal from '../components/Modal.svelte';
@@ -27,6 +30,10 @@
   let matrixEnabled = true;
   let beepEnabled = false;
   let reducedMotion = false;
+  let speechEnabled = false;
+  let autoAdvanceEnabled = false;
+  let autoAdvanceInterval = 8;
+  let speechAvailable = false;
   let renderMode: RenderMode = RenderMode.Canvas;
   let auraColorKey = DEFAULT_AURA_SETTINGS.colorKey;
   let auraSize = DEFAULT_AURA_SETTINGS.size;
@@ -34,6 +41,9 @@
   const unsubscribe = settings.subscribe((value) => {
     matrixEnabled = value.matrixEnabled;
     beepEnabled = value.beepEnabled;
+    speechEnabled = value.speechEnabled;
+    autoAdvanceEnabled = value.autoAdvanceEnabled;
+    autoAdvanceInterval = value.autoAdvanceInterval;
     reducedMotion = value.matrix.reducedMotion;
     renderMode = value.matrix.renderMode;
     auraColorKey = value.aura.colorKey;
@@ -42,6 +52,13 @@
 
   onDestroy(() => {
     unsubscribe();
+  });
+
+  onMount(() => {
+    speechAvailable =
+      typeof window !== 'undefined' &&
+      typeof window.speechSynthesis !== 'undefined' &&
+      typeof SpeechSynthesisUtterance !== 'undefined';
   });
 
   function handleMatrixChange(event: Event): void {
@@ -54,6 +71,27 @@
     const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
     if (!input) return;
     setBeepEnabled(input.checked);
+  }
+
+  function handleSpeechChange(event: Event): void {
+    const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
+    if (!input) return;
+    setSpeechEnabled(input.checked);
+  }
+
+  function handleAutoAdvanceChange(event: Event): void {
+    const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
+    if (!input) return;
+    setAutoAdvanceEnabled(input.checked);
+  }
+
+  function handleAutoAdvanceIntervalInput(event: Event): void {
+    const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
+    if (!input) return;
+    const next = Number.parseFloat(input.value);
+    if (Number.isFinite(next)) {
+      setAutoAdvanceInterval(next);
+    }
   }
 
   function handleReducedMotionChange(event: Event): void {
@@ -110,6 +148,48 @@
         <span>Sound chime before quotes</span>
         <input type="checkbox" checked={beepEnabled} on:change={handleBeepChange} />
       </label>
+      <div class="space-y-2 rounded-2xl bg-white/5 px-4 py-3">
+        <label class="flex items-center justify-between gap-4">
+          <span>Read quotes aloud</span>
+          <input
+            type="checkbox"
+            checked={speechEnabled && speechAvailable}
+            on:change={handleSpeechChange}
+            disabled={!speechAvailable}
+            aria-disabled={!speechAvailable}
+          />
+        </label>
+        {#if !speechAvailable}
+          <p class="text-[0.7rem] text-white/50">
+            Voice playback requires a browser with speech synthesis support.
+          </p>
+        {/if}
+      </div>
+      <div class="space-y-2 rounded-2xl bg-white/5 px-4 py-3">
+        <label class="flex items-center justify-between gap-4">
+          <span>Auto-refresh quotes</span>
+          <input type="checkbox" checked={autoAdvanceEnabled} on:change={handleAutoAdvanceChange} />
+        </label>
+        <div class="text-xs text-white/60">
+          Choose how often a new quote appears automatically.
+        </div>
+        <div class="flex items-center gap-3">
+          <input
+            type="range"
+            class="w-full accent-white/80"
+            min="5"
+            max="60"
+            step="1"
+            value={autoAdvanceInterval}
+            on:input={handleAutoAdvanceIntervalInput}
+            disabled={!autoAdvanceEnabled}
+            aria-disabled={!autoAdvanceEnabled}
+          />
+          <span class="w-16 text-right text-xs font-semibold text-white/70">
+            {autoAdvanceInterval}s
+          </span>
+        </div>
+      </div>
     </section>
 
     <section class="space-y-3">

--- a/src/app/stores/settings.ts
+++ b/src/app/stores/settings.ts
@@ -12,9 +12,16 @@ import {
 export interface AppSettingsState {
   matrixEnabled: boolean;
   beepEnabled: boolean;
+  speechEnabled: boolean;
+  autoAdvanceEnabled: boolean;
+  autoAdvanceInterval: number;
   matrix: MatrixConfig;
   aura: AuraSettings;
 }
+
+const AUTO_ADVANCE_INTERVAL_MIN = 5;
+const AUTO_ADVANCE_INTERVAL_MAX = 60;
+const DEFAULT_AUTO_ADVANCE_INTERVAL = 8;
 
 const STORAGE_KEY = 'vibeme:settings:v1';
 
@@ -40,6 +47,9 @@ function resolveInitialState(): AppSettingsState {
   const baseState: AppSettingsState = {
     matrixEnabled: true,
     beepEnabled: false,
+    speechEnabled: false,
+    autoAdvanceEnabled: false,
+    autoAdvanceInterval: DEFAULT_AUTO_ADVANCE_INTERVAL,
     matrix: baseMatrix,
     aura: baseAura,
   };
@@ -73,10 +83,22 @@ function resolveInitialState(): AppSettingsState {
         ? clamp(parsedAura.size, AURA_SIZE_MIN, AURA_SIZE_MAX)
         : baseAura.size;
 
+    const persistedInterval =
+      typeof parsed.autoAdvanceInterval === 'number' && Number.isFinite(parsed.autoAdvanceInterval)
+        ? clamp(parsed.autoAdvanceInterval, AUTO_ADVANCE_INTERVAL_MIN, AUTO_ADVANCE_INTERVAL_MAX)
+        : baseState.autoAdvanceInterval;
+
     return {
       matrixEnabled:
         typeof parsed.matrixEnabled === 'boolean' ? parsed.matrixEnabled : baseState.matrixEnabled,
       beepEnabled: typeof parsed.beepEnabled === 'boolean' ? parsed.beepEnabled : baseState.beepEnabled,
+      speechEnabled:
+        typeof parsed.speechEnabled === 'boolean' ? parsed.speechEnabled : baseState.speechEnabled,
+      autoAdvanceEnabled:
+        typeof parsed.autoAdvanceEnabled === 'boolean'
+          ? parsed.autoAdvanceEnabled
+          : baseState.autoAdvanceEnabled,
+      autoAdvanceInterval: persistedInterval,
       matrix: {
         ...baseMatrix,
         ...(parsed.matrix && typeof parsed.matrix === 'object' ? parsed.matrix : {}),
@@ -126,6 +148,33 @@ export function setBeepEnabled(enabled: boolean): void {
 
 export function toggleBeepEnabled(): void {
   store.update((state) => ({ ...state, beepEnabled: !state.beepEnabled }));
+}
+
+export function setSpeechEnabled(enabled: boolean): void {
+  store.update((state) => ({ ...state, speechEnabled: enabled }));
+}
+
+export function setAutoAdvanceEnabled(enabled: boolean): void {
+  store.update((state) => ({ ...state, autoAdvanceEnabled: enabled }));
+}
+
+export function setAutoAdvanceInterval(seconds: number): void {
+  if (!Number.isFinite(seconds)) {
+    return;
+  }
+
+  const clamped = clamp(seconds, AUTO_ADVANCE_INTERVAL_MIN, AUTO_ADVANCE_INTERVAL_MAX);
+
+  store.update((state) => {
+    if (state.autoAdvanceInterval === clamped) {
+      return state;
+    }
+
+    return {
+      ...state,
+      autoAdvanceInterval: clamped,
+    };
+  });
 }
 
 export function updateMatrixConfig(patch: Partial<MatrixConfig>): void {


### PR DESCRIPTION
## Summary
- add persisted settings for quote narration and automatic rotation intervals
- wire the app shell to schedule next quotes and trigger speech synthesis when enabled
- extend the settings panel with toggles for narration and auto-refresh, including slider control and support detection

## Testing
- npm run lint
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbfcd5bb90832bbf562c2b2fba2a37