### PR TITLE
Add quote search and animated transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@eslint/js": "^9.35.0",
         "@sveltejs/vite-plugin-svelte": "^6.2.0",
+        "@testing-library/svelte": "^5.2.4",
         "@tsconfig/svelte": "^5.0.3",
         "autoprefixer": "^10.4.21",
         "cross-env": "^7.0.3",
@@ -50,6 +51,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1233,6 +1276,62 @@
         "vite": "^6.3.0 || ^7.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/svelte": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.2.8.tgz",
+      "integrity": "sha512-ucQOtGsJhtawOEtUmbR4rRh53e6RbM1KUluJIXRmh6D4UzxR847iIqqjRtg9mHNFmGQ8Vkam9yVcR5d1mhIHKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "9.x.x || 10.x.x"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0",
+        "vite": "*",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -1247,6 +1346,13 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.5.tgz",
       "integrity": "sha512-48fAnUjKye38FvMiNOj0J9I/4XlQQiZlpe9xaNPfe8vy2Y1hFBt8g1yqf2EGjVvHavo4jf2lC+TQyENCr4BJBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2272,6 +2378,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2283,6 +2399,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3498,6 +3621,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -4131,6 +4264,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -4180,6 +4351,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.2.0",
     "@tsconfig/svelte": "^5.0.3",
+    "@testing-library/svelte": "^5.2.4",
     "autoprefixer": "^10.4.21",
     "cross-env": "^7.0.3",
     "jsdom": "^22.1.0",

--- a/src/app/AppShell.svelte
+++ b/src/app/AppShell.svelte
@@ -11,6 +11,8 @@ import SettingsPanel from './panels/SettingsPanel.svelte';
 import { currentQuote, ensureInitialQuote, requestNextQuote, type QuoteViewModel } from './stores/quote';
 import { settings, setSpeechEnabled } from './stores/settings';
 
+const currentYear = new Date().getFullYear();
+
   let quote: QuoteViewModel | null = null;
 let settingsOpen = false;
 let autoAdvanceEnabled = false;
@@ -180,7 +182,7 @@ export let navigateTo: (route: 'home' | 'about') => void = () => {};
   </main>
 
   <footer class="app-footer">
-    <p>&copy; 2025 Vibe Me. All Rights Reserved.</p>
+    <p>&copy; {currentYear} Vibe Me. All Rights Reserved.</p>
   </footer>
 </div>
 

--- a/src/app/AppShell.svelte
+++ b/src/app/AppShell.svelte
@@ -5,6 +5,7 @@ import MatrixLayer from './features/matrix/MatrixLayer.svelte';
 import ControlsBar from './components/ControlsBar.svelte';
 import HeaderBar from './components/HeaderBar.svelte';
 import QuoteCard from './components/QuoteCard.svelte';
+import QuoteSearch from './components/QuoteSearch.svelte';
 import FavoritesPanel from './panels/FavoritesPanel.svelte';
 import SettingsPanel from './panels/SettingsPanel.svelte';
 import { currentQuote, ensureInitialQuote, requestNextQuote, type QuoteViewModel } from './stores/quote';
@@ -155,26 +156,130 @@ export let navigateTo: (route: 'home' | 'about') => void = () => {};
   }
 </script>
 
-<AuraGlow />
-<MatrixLayer />
+<div class="app-shell">
+  <AuraGlow />
+  <MatrixLayer />
 
-<main class="relative z-[100] flex flex-col gap-8 py-14">
-  <section class="app-surface">
-    <HeaderBar {quote} onOpenSettings={openSettings} />
-    <QuoteCard {quote} />
-    <ControlsBar {quote} />
-  </section>
+  <main class="relative z-[100] flex flex-1 flex-col gap-8 py-14">
+    <section class="app-surface">
+      <HeaderBar {quote} onOpenSettings={openSettings} />
+      <QuoteSearch />
+      <QuoteCard {quote} />
+      <ControlsBar {quote} />
+    </section>
 
-  <footer class="z-[100] mx-auto flex w-full max-w-3xl justify-center px-4">
-    <button
-      type="button"
-      class="glass-button"
-      on:click={() => navigateTo('about')}
-    >
-      Learn about VibeMe
-    </button>
+    <div class="z-[100] mx-auto flex w-full max-w-3xl justify-center px-4">
+      <button
+        type="button"
+        class="glass-button cta-button"
+        on:click={() => navigateTo('about')}
+      >
+        Learn about VibeMe
+      </button>
+    </div>
+  </main>
+
+  <footer class="app-footer">
+    <p>&copy; 2025 Vibe Me. All Rights Reserved.</p>
   </footer>
-</main>
+</div>
 
 <FavoritesPanel />
 <SettingsPanel open={settingsOpen} onClose={closeSettings} />
+
+<style>
+  .app-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  .cta-button {
+    position: relative;
+    padding-inline: 2.75rem;
+    letter-spacing: 0.2em;
+    box-shadow:
+      0 0 0 rgba(0, 255, 255, 0.25),
+      0 0 0 rgba(255, 0, 255, 0.15);
+    animation: ctaPulse 4s ease-in-out infinite;
+  }
+
+  .cta-button::after {
+    content: '';
+    position: absolute;
+    left: 22%;
+    right: 22%;
+    bottom: 0.4rem;
+    height: 2px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, #ff00ff, #00ffff);
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform 0.4s ease;
+  }
+
+  .cta-button:hover::after,
+  .cta-button:focus-visible::after {
+    transform: scaleX(1);
+  }
+
+  .cta-button:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.4);
+    outline-offset: 3px;
+  }
+
+  @keyframes ctaPulse {
+    0%,
+    100% {
+      box-shadow:
+        0 0 18px rgba(0, 255, 255, 0.25),
+        0 0 36px rgba(255, 0, 255, 0.18);
+    }
+
+    50% {
+      box-shadow:
+        0 0 26px rgba(0, 255, 255, 0.32),
+        0 0 48px rgba(255, 0, 255, 0.24);
+    }
+  }
+
+  .app-footer {
+    text-align: center;
+    padding: 1.5rem;
+    margin-top: auto;
+    font-size: 0.875rem;
+    color: #888;
+    opacity: 0;
+    transform: translateY(12px);
+    animation: footerFadeIn 0.8s ease-out 0.2s forwards;
+  }
+
+  @keyframes footerFadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cta-button {
+      animation: none;
+      box-shadow: 0 0 18px rgba(0, 255, 255, 0.25);
+    }
+
+    .cta-button::after {
+      transition: none;
+    }
+
+    .app-footer {
+      animation: none;
+      opacity: 1;
+      transform: none;
+    }
+  }
+</style>

--- a/src/app/components/HeaderBar.svelte
+++ b/src/app/components/HeaderBar.svelte
@@ -17,10 +17,13 @@
 
 <header class="flex flex-wrap items-center justify-between gap-4 text-white">
   <div>
-    <h1 class="text-3xl font-semibold tracking-tight heading-font">VibeMe</h1>
-    {#if quote?.category}
-      <p class="text-sm text-white/70">Exploring {quote.category} vibes</p>
-    {/if}
+    <div class="header-title-container">
+      <h1 class="title-vibe">Vibe</h1>
+      <h1 class="title-me">Me</h1>
+    </div>
+    <p class="tagline">
+      {quote ? 'Tune into your next vibe.' : 'Preparing your first vibe...'}
+    </p>
   </div>
 
   <div class="flex items-center gap-2">
@@ -46,3 +49,34 @@
     </button>
   </div>
 </header>
+
+<style>
+  .header-title-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 1rem 0;
+  }
+
+  .title-vibe,
+  .title-me {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 3rem;
+    font-weight: bold;
+    text-shadow: 0 0 5px rgba(255, 255, 255, 0.5);
+  }
+
+  .title-vibe {
+    color: #ff00ff;
+  }
+
+  .title-me {
+    color: #00ffff;
+  }
+
+  .tagline {
+    margin: 0;
+    font-size: 0.875rem;
+    color: rgba(255, 255, 255, 0.7);
+  }
+</style>

--- a/src/app/components/QuoteCard.svelte
+++ b/src/app/components/QuoteCard.svelte
@@ -1,10 +1,35 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+  import { fade, fly, scale } from 'svelte/transition';
+  import { quintIn, quintOut } from 'svelte/easing';
   import type { QuoteViewModel } from '../stores/quote';
+  import { quoteLoading } from '../stores/quote';
 
   export let quote: QuoteViewModel | null = null;
+
+  let reduceMotion = false;
+
+  function motion(duration: number): number {
+    return reduceMotion ? 0 : duration;
+  }
+
+  onMount(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => {
+      reduceMotion = media.matches;
+    };
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  });
 </script>
 
 <section
+  class:loading={$quoteLoading}
   class="panel-surface relative overflow-hidden p-6 text-center text-white"
   aria-live="polite"
   aria-atomic="true"
@@ -14,25 +39,105 @@
     aria-hidden="true"
   ></div>
 
-  <p class="quote-text-font text-2xl leading-relaxed md:text-3xl">
-    {#if quote?.text}
-      {quote.text}
-    {:else}
-      Loading your next dose of inspiration…
-    {/if}
-  </p>
+  {#key quote?.id ?? quote?.text ?? 'loading'}
+    <div
+      class="quote-animator"
+      in:fly={{ y: 36, duration: motion(420), easing: quintOut }}
+      out:fly={{ y: -28, duration: motion(320), easing: quintIn }}
+    >
+      <div
+        class="quote-animator-shell"
+        in:scale={{ start: 0.92, duration: motion(420), easing: quintOut }}
+        out:scale={{ start: 0.92, duration: motion(260), easing: quintIn }}
+      >
+        <div
+          class="quote-animator-body"
+          in:fade={{ duration: motion(360) }}
+          out:fade={{ duration: motion(220) }}
+        >
+          <p class="quote-text-font text-2xl leading-relaxed md:text-3xl">
+            {#if quote?.text}
+              {quote.text}
+            {:else}
+              Loading your next dose of inspiration…
+            {/if}
+          </p>
 
-  <footer class="mt-6 text-base italic text-white/80">
-    {#if quote?.author}
-      — {quote.author}
-    {:else if quote?.text}
-      — Unknown
-    {/if}
-  </footer>
-
-  {#if quote?.category}
-    <span class="mt-6 inline-flex items-center rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-wider text-white/70">
-      {quote.category}
-    </span>
-  {/if}
+          <footer class="quote-author">
+            {#if quote?.author}
+              — {quote.author}
+            {:else if quote?.text}
+              — Unknown
+            {/if}
+          </footer>
+        </div>
+      </div>
+    </div>
+  {/key}
 </section>
+
+<style>
+  .quote-animator {
+    display: flex;
+    justify-content: center;
+    position: relative;
+  }
+
+  .quote-animator-shell {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  }
+
+  .quote-animator-body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  .quote-author {
+    margin-top: 0.5rem;
+    font-size: 1rem;
+    font-style: italic;
+    color: rgba(255, 255, 255, 0.75);
+  }
+
+  section.loading::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.08), transparent 45%, transparent 55%, rgba(0, 255, 255, 0.08));
+    opacity: 0;
+    animation: shimmer 1.4s ease-in-out infinite;
+    pointer-events: none;
+  }
+
+  @keyframes shimmer {
+    0%,
+    100% {
+      opacity: 0;
+      transform: translateX(-10%);
+    }
+
+    40% {
+      opacity: 0.6;
+    }
+
+    50% {
+      opacity: 0.7;
+      transform: translateX(10%);
+    }
+
+    60% {
+      opacity: 0.6;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    section.loading::after {
+      animation: none;
+      opacity: 0;
+    }
+  }
+</style>

--- a/src/app/components/QuoteCard.svelte
+++ b/src/app/components/QuoteCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+import { onMount } from 'svelte';
   import { fade, fly, scale } from 'svelte/transition';
   import { quintIn, quintOut } from 'svelte/easing';
   import type { QuoteViewModel } from '../stores/quote';
@@ -7,11 +7,23 @@
 
   export let quote: QuoteViewModel | null = null;
 
-  let reduceMotion = false;
+let reduceMotion = false;
+let transitionDepth = 0;
+let isTransitioning = false;
 
-  function motion(duration: number): number {
-    return reduceMotion ? 0 : duration;
-  }
+function motion(duration: number): number {
+  return reduceMotion ? 0 : duration;
+}
+
+function markTransitionStart(): void {
+  transitionDepth += 1;
+  isTransitioning = transitionDepth > 0;
+}
+
+function markTransitionEnd(): void {
+  transitionDepth = Math.max(0, transitionDepth - 1);
+  isTransitioning = transitionDepth > 0;
+}
 
   onMount(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -42,16 +54,23 @@
   {#key quote?.id ?? quote?.text ?? 'loading'}
     <div
       class="quote-animator"
+      class:is-transitioning={isTransitioning}
       in:fly={{ y: 36, duration: motion(420), easing: quintOut }}
       out:fly={{ y: -28, duration: motion(320), easing: quintIn }}
+      on:introstart={markTransitionStart}
+      on:outrostart={markTransitionStart}
+      on:introend={markTransitionEnd}
+      on:outroend={markTransitionEnd}
     >
       <div
         class="quote-animator-shell"
+        class:is-transitioning={isTransitioning}
         in:scale={{ start: 0.92, duration: motion(420), easing: quintOut }}
         out:scale={{ start: 0.92, duration: motion(260), easing: quintIn }}
       >
         <div
           class="quote-animator-body"
+          class:is-transitioning={isTransitioning}
           in:fade={{ duration: motion(360) }}
           out:fade={{ duration: motion(220) }}
         >
@@ -81,6 +100,12 @@
     display: flex;
     justify-content: center;
     position: relative;
+  }
+
+  .quote-animator.is-transitioning,
+  .quote-animator-shell.is-transitioning,
+  .quote-animator-body.is-transitioning {
+    will-change: transform, opacity;
   }
 
   .quote-animator-shell {

--- a/src/app/components/QuoteSearch.svelte
+++ b/src/app/components/QuoteSearch.svelte
@@ -73,7 +73,7 @@
 </script>
 
 <form class="quote-search" role="search" aria-label="Search quotes" on:submit={handleSubmit}>
-  <div class="search-shell" class:is-loading={isLoading}>
+  <div class="search-shell" class:is-loading={isLoading} aria-busy={isLoading}>
     <span class="search-icon" aria-hidden="true">
       <Fa icon={faSearch} class="h-4 w-4 flex-shrink-0 text-white/50" />
     </span>
@@ -86,9 +86,14 @@
       autocomplete="off"
       spellcheck="false"
       enterkeyhint="search"
+      maxlength="100"
       bind:value={query}
       on:input={handleInput}
     />
+
+    {#if isLoading}
+      <span class="loading-indicator" role="status" aria-live="polite">Searching…</span>
+    {/if}
 
     {#if query}
       <button
@@ -129,6 +134,13 @@
     backdrop-filter: blur(18px);
     position: relative;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .loading-indicator {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.72);
+    letter-spacing: 0.04em;
   }
 
   .search-icon {

--- a/src/app/components/QuoteSearch.svelte
+++ b/src/app/components/QuoteSearch.svelte
@@ -1,0 +1,234 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { FontAwesomeIcon as Fa } from '@fortawesome/svelte-fontawesome';
+  import { faCircleXmark, faSearch } from '@fortawesome/free-solid-svg-icons';
+  import { applyQuoteFilter, quoteLoading } from '../stores/quote';
+
+  const SEARCH_DELAY = 280;
+
+  let query = '';
+  let lastApplied: string | null = null;
+  let debounceHandle: ReturnType<typeof setTimeout> | null = null;
+  let isLoading = false;
+
+  $: isLoading = $quoteLoading;
+
+  function clearDebounce(): void {
+    if (debounceHandle) {
+      clearTimeout(debounceHandle);
+      debounceHandle = null;
+    }
+  }
+
+  async function runSearch(rawValue: string): Promise<void> {
+    const normalized = rawValue.trim();
+
+    if (lastApplied === normalized) {
+      return;
+    }
+
+    lastApplied = normalized;
+
+    try {
+      if (normalized) {
+        await applyQuoteFilter({ search: normalized });
+      } else {
+        await applyQuoteFilter(null);
+      }
+    } catch (error) {
+      console.warn('[quotes] search failed', error);
+    }
+  }
+
+  function scheduleSearch(value: string): void {
+    clearDebounce();
+    debounceHandle = setTimeout(() => {
+      debounceHandle = null;
+      void runSearch(value);
+    }, SEARCH_DELAY);
+  }
+
+  function handleInput(event: Event): void {
+    const target = event.currentTarget as HTMLInputElement | null;
+    const value = target?.value ?? '';
+    query = value;
+    scheduleSearch(value);
+  }
+
+  function handleSubmit(event: Event): void {
+    event.preventDefault();
+    clearDebounce();
+    void runSearch(query);
+  }
+
+  function handleClear(): void {
+    query = '';
+    clearDebounce();
+    void runSearch('');
+  }
+
+  onDestroy(() => {
+    clearDebounce();
+  });
+</script>
+
+<form class="quote-search" role="search" aria-label="Search quotes" on:submit={handleSubmit}>
+  <div class="search-shell" class:is-loading={isLoading}>
+    <span class="search-icon" aria-hidden="true">
+      <Fa icon={faSearch} class="h-4 w-4 flex-shrink-0 text-white/50" />
+    </span>
+
+    <input
+      class="search-input"
+      type="search"
+      name="quote-search"
+      placeholder="Search quotes or authors..."
+      autocomplete="off"
+      spellcheck="false"
+      enterkeyhint="search"
+      bind:value={query}
+      on:input={handleInput}
+    />
+
+    {#if query}
+      <button
+        type="button"
+        class="clear-button"
+        aria-label="Clear search"
+        on:click={handleClear}
+      >
+        <Fa icon={faCircleXmark} class="h-4 w-4" />
+      </button>
+    {/if}
+  </div>
+
+  <p class="search-hint">Search matches quote text or authors from the full VibeMe archive.</p>
+</form>
+
+<style>
+  .quote-search {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: stretch;
+    text-align: left;
+    color: rgba(255, 255, 255, 0.75);
+  }
+
+  .search-shell {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.85rem 1.1rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow:
+      inset 0 0 0 rgba(255, 255, 255, 0.08),
+      0 8px 24px rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(18px);
+    position: relative;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .search-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .search-shell:focus-within {
+    border-color: rgba(0, 255, 255, 0.6);
+    box-shadow:
+      inset 0 0 0 rgba(255, 255, 255, 0.1),
+      0 10px 28px rgba(56, 189, 248, 0.25);
+  }
+
+  .search-shell.is-loading::after {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(0, 255, 255, 0.4), rgba(255, 0, 255, 0.4));
+    opacity: 0;
+    animation: pulse-border 1.4s ease-in-out infinite;
+    pointer-events: none;
+  }
+
+  .search-input {
+    flex: 1 1 auto;
+    border: none;
+    background: transparent;
+    color: white;
+    font-size: 1rem;
+    outline: none;
+    min-width: 0;
+  }
+
+  .search-input::placeholder {
+    color: rgba(255, 255, 255, 0.4);
+  }
+
+  .clear-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 1.75rem;
+    width: 1.75rem;
+    border-radius: 999px;
+    border: none;
+    background: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.8);
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+  }
+
+  .clear-button:hover,
+  .clear-button:focus-visible {
+    background: rgba(255, 255, 255, 0.2);
+    transform: scale(1.05);
+  }
+
+  .clear-button:focus-visible {
+    outline: 2px solid rgba(0, 255, 255, 0.4);
+    outline-offset: 2px;
+  }
+
+  .search-hint {
+    margin: 0;
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.55);
+  }
+
+  @keyframes pulse-border {
+    0%,
+    100% {
+      opacity: 0;
+      transform: scale(0.99);
+    }
+
+    40%,
+    60% {
+      opacity: 0.7;
+      transform: scale(1);
+    }
+  }
+
+  @media (max-width: 640px) {
+    .search-hint {
+      text-align: center;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .search-shell,
+    .clear-button {
+      transition: none;
+    }
+
+    .search-shell.is-loading::after {
+      animation: none;
+      opacity: 0;
+    }
+  }
+</style>

--- a/src/app/components/QuoteSearch.test.ts
+++ b/src/app/components/QuoteSearch.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/svelte/vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+
+type LoadingSubscriber = (value: boolean) => void;
+
+const loadingSubscribers: LoadingSubscriber[] = [];
+
+vi.mock('../stores/quote', () => {
+  const mockApplyQuoteFilter = vi.fn(async () => null);
+  return {
+    applyQuoteFilter: mockApplyQuoteFilter,
+    quoteLoading: {
+      subscribe(subscriber: LoadingSubscriber) {
+        loadingSubscribers.push(subscriber);
+        subscriber(false);
+        return () => {
+          const index = loadingSubscribers.indexOf(subscriber);
+          if (index >= 0) {
+            loadingSubscribers.splice(index, 1);
+          }
+        };
+      },
+    },
+    __mockEmitLoading(value: boolean) {
+      loadingSubscribers.forEach((subscriber) => subscriber(value));
+    },
+    __mockApplyQuoteFilter: mockApplyQuoteFilter,
+  };
+}, { virtual: true });
+
+const quoteStores = (await import('../stores/quote')) as unknown as {
+  applyQuoteFilter: ReturnType<typeof vi.fn>;
+  __mockEmitLoading: (value: boolean) => void;
+  __mockApplyQuoteFilter: ReturnType<typeof vi.fn>;
+};
+
+const applyQuoteFilter = quoteStores.__mockApplyQuoteFilter;
+const emitLoading = quoteStores.__mockEmitLoading;
+
+import QuoteSearch from './QuoteSearch.svelte';
+
+describe('QuoteSearch', () => {
+  beforeEach(() => {
+    applyQuoteFilter.mockClear();
+    applyQuoteFilter.mockResolvedValue(null);
+    emitLoading(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces search input before applying the filter', async () => {
+    vi.useFakeTimers();
+    const { getByPlaceholderText } = render(QuoteSearch);
+    const input = getByPlaceholderText('Search quotes or authors...') as HTMLInputElement;
+
+    expect(input.getAttribute('maxlength')).toBe('100');
+
+    await fireEvent.input(input, { target: { value: '  stoic  ' } });
+    expect(applyQuoteFilter).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(280);
+
+    expect(applyQuoteFilter).toHaveBeenCalledTimes(1);
+    expect(applyQuoteFilter).toHaveBeenCalledWith({ search: 'stoic' });
+  });
+
+  it('clears the query when the clear button is clicked', async () => {
+    vi.useFakeTimers();
+    const { getByPlaceholderText, getByRole } = render(QuoteSearch);
+    const input = getByPlaceholderText('Search quotes or authors...') as HTMLInputElement;
+
+    await fireEvent.input(input, { target: { value: 'zen' } });
+    await vi.runAllTimersAsync();
+
+    const clearButton = getByRole('button', { name: /clear search/i });
+    await fireEvent.click(clearButton);
+
+    expect(input.value).toBe('');
+    expect(applyQuoteFilter).toHaveBeenCalledTimes(2);
+    expect(applyQuoteFilter).toHaveBeenLastCalledWith(null);
+  });
+
+  it('submits immediately when the form is submitted', async () => {
+    vi.useFakeTimers();
+    const { getByPlaceholderText, getByRole } = render(QuoteSearch);
+    const input = getByPlaceholderText('Search quotes or authors...') as HTMLInputElement;
+
+    await fireEvent.input(input, { target: { value: 'focus' } });
+    const form = getByRole('search');
+    await fireEvent.submit(form);
+
+    expect(applyQuoteFilter).toHaveBeenCalledTimes(1);
+    expect(applyQuoteFilter).toHaveBeenCalledWith({ search: 'focus' });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('shows a visible loading indicator when quotes are loading', async () => {
+    const { queryByText } = render(QuoteSearch);
+
+    expect(queryByText('Searching…')).toBeNull();
+
+    emitLoading(true);
+    await Promise.resolve();
+    expect(queryByText('Searching…')).not.toBeNull();
+
+    emitLoading(false);
+    await Promise.resolve();
+    expect(queryByText('Searching…')).toBeNull();
+  });
+});

--- a/src/app/stores/quote.test.ts
+++ b/src/app/stores/quote.test.ts
@@ -9,7 +9,7 @@ import {
   __testing__,
 } from './quote';
 
-const { clearState } = __testing__;
+const { clearState, normalizeFilter } = __testing__;
 
 describe('quote store', () => {
   beforeEach(() => {
@@ -49,5 +49,36 @@ describe('quote store', () => {
     if (cleared?.category) {
       expect(cleared.category.toLowerCase()).not.toBe('productivity');
     }
+  });
+
+  describe('normalizeFilter', () => {
+    it('trims category strings and ignores all keyword', () => {
+      expect(normalizeFilter('  focus  ')).toEqual({ category: 'focus' });
+      expect(normalizeFilter('all')).toBeNull();
+      expect(normalizeFilter('  ALL ')).toBeNull();
+    });
+
+    it('cleans filter objects by removing empty values', () => {
+      expect(
+        normalizeFilter({
+          category: '  inspiration  ',
+          search: '   deep work   ',
+        }),
+      ).toEqual({ category: 'inspiration', search: 'deep work' });
+
+      expect(
+        normalizeFilter({
+          category: ' all ',
+          search: '   ',
+        }),
+      ).toBeNull();
+
+      expect(
+        normalizeFilter({
+          category: null,
+          search: undefined,
+        }),
+      ).toBeNull();
+    });
   });
 });

--- a/src/app/stores/quote.ts
+++ b/src/app/stores/quote.ts
@@ -68,6 +68,19 @@ function normalizeFilter(payload: QuoteFilterEventPayload): QuoteFilter | null {
         delete filter.category;
       }
     }
+    if ('search' in filter) {
+      const search = filter.search;
+      if (typeof search === 'string') {
+        const trimmed = search.trim();
+        if (trimmed) {
+          filter.search = trimmed;
+        } else {
+          delete filter.search;
+        }
+      } else if (search == null) {
+        delete filter.search;
+      }
+    }
     return Object.keys(filter).length ? filter : null;
   }
   return null;

--- a/src/test/mocks/FontAwesomeIcon.svelte
+++ b/src/test/mocks/FontAwesomeIcon.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let icon: unknown;
+  $: void icon;
+</script>
+
+<svg data-testid="icon" aria-hidden="true"></svg>

--- a/src/test/mocks/fontawesome.ts
+++ b/src/test/mocks/fontawesome.ts
@@ -1,0 +1,4 @@
+import Component from './FontAwesomeIcon.svelte';
+
+export { Component as FontAwesomeIcon };
+export default Component;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,23 @@
 import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
   },
+  resolve: {
+    alias: {
+      '@fortawesome/svelte-fontawesome': resolve(
+        __dirname,
+        'src/test/mocks/fontawesome.ts',
+      ),
+    },
+    conditions: ['browser', 'svelte'],
+  },
+  plugins: [svelte()],
 });


### PR DESCRIPTION
## Summary
- add a glassmorphism search form that filters quotes by text or author and integrates it into the main shell
- animate quote transitions with layered fly, scale, and fade effects while honoring reduced-motion preferences and hiding category badges
- refresh the header tagline to avoid exposing categories while still signaling load state and sanitise search filters in the quote store

## Testing
- npm run lint
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc3a0d34c8832b8bbe6cd6f2a2b181