### PR TITLE
Add QuoteSearch tests and loading indicator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@eslint/js": "^9.35.0",
         "@sveltejs/vite-plugin-svelte": "^6.2.0",
+        "@testing-library/svelte": "^5.2.4",
         "@tsconfig/svelte": "^5.0.3",
         "autoprefixer": "^10.4.21",
         "cross-env": "^7.0.3",
@@ -50,6 +51,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1233,6 +1276,62 @@
         "vite": "^6.3.0 || ^7.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/svelte": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.2.8.tgz",
+      "integrity": "sha512-ucQOtGsJhtawOEtUmbR4rRh53e6RbM1KUluJIXRmh6D4UzxR847iIqqjRtg9mHNFmGQ8Vkam9yVcR5d1mhIHKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "9.x.x || 10.x.x"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0",
+        "vite": "*",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -1247,6 +1346,13 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.5.tgz",
       "integrity": "sha512-48fAnUjKye38FvMiNOj0J9I/4XlQQiZlpe9xaNPfe8vy2Y1hFBt8g1yqf2EGjVvHavo4jf2lC+TQyENCr4BJBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2272,6 +2378,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2283,6 +2399,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3498,6 +3621,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -4131,6 +4264,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -4180,6 +4351,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.2.0",
     "@tsconfig/svelte": "^5.0.3",
+    "@testing-library/svelte": "^5.2.4",
     "autoprefixer": "^10.4.21",
     "cross-env": "^7.0.3",
     "jsdom": "^22.1.0",

--- a/src/app/AppShell.svelte
+++ b/src/app/AppShell.svelte
@@ -11,6 +11,8 @@ import SettingsPanel from './panels/SettingsPanel.svelte';
 import { currentQuote, ensureInitialQuote, requestNextQuote, type QuoteViewModel } from './stores/quote';
 import { settings, setSpeechEnabled } from './stores/settings';
 
+const currentYear = new Date().getFullYear();
+
   let quote: QuoteViewModel | null = null;
 let settingsOpen = false;
 let autoAdvanceEnabled = false;
@@ -180,7 +182,7 @@ export let navigateTo: (route: 'home' | 'about') => void = () => {};
   </main>
 
   <footer class="app-footer">
-    <p>&copy; 2025 Vibe Me. All Rights Reserved.</p>
+    <p>&copy; {currentYear} Vibe Me. All Rights Reserved.</p>
   </footer>
 </div>
 

--- a/src/app/components/QuoteCard.svelte
+++ b/src/app/components/QuoteCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+import { onMount } from 'svelte';
   import { fade, fly, scale } from 'svelte/transition';
   import { quintIn, quintOut } from 'svelte/easing';
   import type { QuoteViewModel } from '../stores/quote';
@@ -7,11 +7,23 @@
 
   export let quote: QuoteViewModel | null = null;
 
-  let reduceMotion = false;
+let reduceMotion = false;
+let transitionDepth = 0;
+let isTransitioning = false;
 
-  function motion(duration: number): number {
-    return reduceMotion ? 0 : duration;
-  }
+function motion(duration: number): number {
+  return reduceMotion ? 0 : duration;
+}
+
+function markTransitionStart(): void {
+  transitionDepth += 1;
+  isTransitioning = transitionDepth > 0;
+}
+
+function markTransitionEnd(): void {
+  transitionDepth = Math.max(0, transitionDepth - 1);
+  isTransitioning = transitionDepth > 0;
+}
 
   onMount(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -42,16 +54,23 @@
   {#key quote?.id ?? quote?.text ?? 'loading'}
     <div
       class="quote-animator"
+      class:is-transitioning={isTransitioning}
       in:fly={{ y: 36, duration: motion(420), easing: quintOut }}
       out:fly={{ y: -28, duration: motion(320), easing: quintIn }}
+      on:introstart={markTransitionStart}
+      on:outrostart={markTransitionStart}
+      on:introend={markTransitionEnd}
+      on:outroend={markTransitionEnd}
     >
       <div
         class="quote-animator-shell"
+        class:is-transitioning={isTransitioning}
         in:scale={{ start: 0.92, duration: motion(420), easing: quintOut }}
         out:scale={{ start: 0.92, duration: motion(260), easing: quintIn }}
       >
         <div
           class="quote-animator-body"
+          class:is-transitioning={isTransitioning}
           in:fade={{ duration: motion(360) }}
           out:fade={{ duration: motion(220) }}
         >
@@ -81,6 +100,12 @@
     display: flex;
     justify-content: center;
     position: relative;
+  }
+
+  .quote-animator.is-transitioning,
+  .quote-animator-shell.is-transitioning,
+  .quote-animator-body.is-transitioning {
+    will-change: transform, opacity;
   }
 
   .quote-animator-shell {

--- a/src/app/components/QuoteSearch.svelte
+++ b/src/app/components/QuoteSearch.svelte
@@ -73,7 +73,7 @@
 </script>
 
 <form class="quote-search" role="search" aria-label="Search quotes" on:submit={handleSubmit}>
-  <div class="search-shell" class:is-loading={isLoading}>
+  <div class="search-shell" class:is-loading={isLoading} aria-busy={isLoading}>
     <span class="search-icon" aria-hidden="true">
       <Fa icon={faSearch} class="h-4 w-4 flex-shrink-0 text-white/50" />
     </span>
@@ -86,9 +86,14 @@
       autocomplete="off"
       spellcheck="false"
       enterkeyhint="search"
+      maxlength="100"
       bind:value={query}
       on:input={handleInput}
     />
+
+    {#if isLoading}
+      <span class="loading-indicator" role="status" aria-live="polite">Searching…</span>
+    {/if}
 
     {#if query}
       <button
@@ -129,6 +134,13 @@
     backdrop-filter: blur(18px);
     position: relative;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .loading-indicator {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.72);
+    letter-spacing: 0.04em;
   }
 
   .search-icon {

--- a/src/app/components/QuoteSearch.test.ts
+++ b/src/app/components/QuoteSearch.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/svelte/vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+
+type LoadingSubscriber = (value: boolean) => void;
+
+const loadingSubscribers: LoadingSubscriber[] = [];
+
+vi.mock('../stores/quote', () => {
+  const mockApplyQuoteFilter = vi.fn(async () => null);
+  return {
+    applyQuoteFilter: mockApplyQuoteFilter,
+    quoteLoading: {
+      subscribe(subscriber: LoadingSubscriber) {
+        loadingSubscribers.push(subscriber);
+        subscriber(false);
+        return () => {
+          const index = loadingSubscribers.indexOf(subscriber);
+          if (index >= 0) {
+            loadingSubscribers.splice(index, 1);
+          }
+        };
+      },
+    },
+    __mockEmitLoading(value: boolean) {
+      loadingSubscribers.forEach((subscriber) => subscriber(value));
+    },
+    __mockApplyQuoteFilter: mockApplyQuoteFilter,
+  };
+}, { virtual: true });
+
+const quoteStores = (await import('../stores/quote')) as unknown as {
+  applyQuoteFilter: ReturnType<typeof vi.fn>;
+  __mockEmitLoading: (value: boolean) => void;
+  __mockApplyQuoteFilter: ReturnType<typeof vi.fn>;
+};
+
+const applyQuoteFilter = quoteStores.__mockApplyQuoteFilter;
+const emitLoading = quoteStores.__mockEmitLoading;
+
+import QuoteSearch from './QuoteSearch.svelte';
+
+describe('QuoteSearch', () => {
+  beforeEach(() => {
+    applyQuoteFilter.mockClear();
+    applyQuoteFilter.mockResolvedValue(null);
+    emitLoading(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces search input before applying the filter', async () => {
+    vi.useFakeTimers();
+    const { getByPlaceholderText } = render(QuoteSearch);
+    const input = getByPlaceholderText('Search quotes or authors...') as HTMLInputElement;
+
+    expect(input.getAttribute('maxlength')).toBe('100');
+
+    await fireEvent.input(input, { target: { value: '  stoic  ' } });
+    expect(applyQuoteFilter).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(280);
+
+    expect(applyQuoteFilter).toHaveBeenCalledTimes(1);
+    expect(applyQuoteFilter).toHaveBeenCalledWith({ search: 'stoic' });
+  });
+
+  it('clears the query when the clear button is clicked', async () => {
+    vi.useFakeTimers();
+    const { getByPlaceholderText, getByRole } = render(QuoteSearch);
+    const input = getByPlaceholderText('Search quotes or authors...') as HTMLInputElement;
+
+    await fireEvent.input(input, { target: { value: 'zen' } });
+    await vi.runAllTimersAsync();
+
+    const clearButton = getByRole('button', { name: /clear search/i });
+    await fireEvent.click(clearButton);
+
+    expect(input.value).toBe('');
+    expect(applyQuoteFilter).toHaveBeenCalledTimes(2);
+    expect(applyQuoteFilter).toHaveBeenLastCalledWith(null);
+  });
+
+  it('submits immediately when the form is submitted', async () => {
+    vi.useFakeTimers();
+    const { getByPlaceholderText, getByRole } = render(QuoteSearch);
+    const input = getByPlaceholderText('Search quotes or authors...') as HTMLInputElement;
+
+    await fireEvent.input(input, { target: { value: 'focus' } });
+    const form = getByRole('search');
+    await fireEvent.submit(form);
+
+    expect(applyQuoteFilter).toHaveBeenCalledTimes(1);
+    expect(applyQuoteFilter).toHaveBeenCalledWith({ search: 'focus' });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('shows a visible loading indicator when quotes are loading', async () => {
+    const { queryByText } = render(QuoteSearch);
+
+    expect(queryByText('Searching…')).toBeNull();
+
+    emitLoading(true);
+    await Promise.resolve();
+    expect(queryByText('Searching…')).not.toBeNull();
+
+    emitLoading(false);
+    await Promise.resolve();
+    expect(queryByText('Searching…')).toBeNull();
+  });
+});

--- a/src/app/stores/quote.test.ts
+++ b/src/app/stores/quote.test.ts
@@ -9,7 +9,7 @@ import {
   __testing__,
 } from './quote';
 
-const { clearState } = __testing__;
+const { clearState, normalizeFilter } = __testing__;
 
 describe('quote store', () => {
   beforeEach(() => {
@@ -49,5 +49,36 @@ describe('quote store', () => {
     if (cleared?.category) {
       expect(cleared.category.toLowerCase()).not.toBe('productivity');
     }
+  });
+
+  describe('normalizeFilter', () => {
+    it('trims category strings and ignores all keyword', () => {
+      expect(normalizeFilter('  focus  ')).toEqual({ category: 'focus' });
+      expect(normalizeFilter('all')).toBeNull();
+      expect(normalizeFilter('  ALL ')).toBeNull();
+    });
+
+    it('cleans filter objects by removing empty values', () => {
+      expect(
+        normalizeFilter({
+          category: '  inspiration  ',
+          search: '   deep work   ',
+        }),
+      ).toEqual({ category: 'inspiration', search: 'deep work' });
+
+      expect(
+        normalizeFilter({
+          category: ' all ',
+          search: '   ',
+        }),
+      ).toBeNull();
+
+      expect(
+        normalizeFilter({
+          category: null,
+          search: undefined,
+        }),
+      ).toBeNull();
+    });
   });
 });

--- a/src/test/mocks/FontAwesomeIcon.svelte
+++ b/src/test/mocks/FontAwesomeIcon.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let icon: unknown;
+  $: void icon;
+</script>
+
+<svg data-testid="icon" aria-hidden="true"></svg>

--- a/src/test/mocks/fontawesome.ts
+++ b/src/test/mocks/fontawesome.ts
@@ -1,0 +1,4 @@
+import Component from './FontAwesomeIcon.svelte';
+
+export { Component as FontAwesomeIcon };
+export default Component;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,23 @@
 import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
   },
+  resolve: {
+    alias: {
+      '@fortawesome/svelte-fontawesome': resolve(
+        __dirname,
+        'src/test/mocks/fontawesome.ts',
+      ),
+    },
+    conditions: ['browser', 'svelte'],
+  },
+  plugins: [svelte()],
 });


### PR DESCRIPTION
## Summary
* add a visible loading indicator and input constraint to the quote search form
* extend quote store normalization tests and add a QuoteSearch component test suite
* improve quote transition performance handling and configure vitest with Svelte-friendly mocks

## Testing
* `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cc6f295dbc832b8bbb7a988606bae7