### PR TITLE
Refine header hero layout with live status components

### DIFF
--- a/src/app/AppShell.svelte
+++ b/src/app/AppShell.svelte
@@ -22,12 +22,51 @@ let mounted = false;
 let speechSupported = false;
 let lastSpeechEnabled = false;
 let autoAdvanceTimer: ReturnType<typeof setTimeout> | null = null;
+let autoAdvanceTicker: ReturnType<typeof setInterval> | null = null;
+let autoAdvanceStart = 0;
+let autoAdvanceDuration = 0;
+let autoAdvanceProgress = 0;
 
-function clearAutoAdvanceTimer(): void {
+function stopAutoAdvanceTicker(): void {
+  if (autoAdvanceTicker) {
+    clearInterval(autoAdvanceTicker);
+    autoAdvanceTicker = null;
+  }
+}
+
+function updateAutoAdvanceProgress(): void {
+  if (!autoAdvanceDuration) {
+    autoAdvanceProgress = 0;
+    return;
+  }
+
+  const elapsed = Date.now() - autoAdvanceStart;
+  const ratio = Math.min(1, Math.max(0, elapsed / autoAdvanceDuration));
+  autoAdvanceProgress = Number.isFinite(ratio) ? ratio : 0;
+}
+
+function clearAutoAdvanceTimer(options: { resetProgress?: boolean } = {}): void {
+  const { resetProgress = true } = options;
+
   if (autoAdvanceTimer) {
     clearTimeout(autoAdvanceTimer);
     autoAdvanceTimer = null;
   }
+
+  stopAutoAdvanceTicker();
+
+  if (resetProgress) {
+    autoAdvanceProgress = 0;
+    autoAdvanceStart = 0;
+    autoAdvanceDuration = 0;
+  }
+}
+
+function startAutoAdvanceTicker(): void {
+  stopAutoAdvanceTicker();
+  autoAdvanceTicker = setInterval(() => {
+    updateAutoAdvanceProgress();
+  }, 1000);
 }
 
 function cancelSpeech(): void {
@@ -63,6 +102,7 @@ function speakQuote(value: QuoteViewModel | null): void {
 
 function scheduleAutoAdvance(): void {
   if (!mounted || !autoAdvanceEnabled) {
+    clearAutoAdvanceTimer();
     return;
   }
 
@@ -74,8 +114,14 @@ function scheduleAutoAdvance(): void {
 
   const delay = Math.max(5, Math.min(60, autoAdvanceInterval)) * 1000;
 
+  autoAdvanceStart = Date.now();
+  autoAdvanceDuration = delay;
+  updateAutoAdvanceProgress();
+  startAutoAdvanceTicker();
+
   autoAdvanceTimer = setTimeout(() => {
-    autoAdvanceTimer = null;
+    clearAutoAdvanceTimer({ resetProgress: false });
+    autoAdvanceProgress = 1;
     requestNextQuote({ reason: 'auto-advance' });
   }, delay);
 }
@@ -156,6 +202,15 @@ export let navigateTo: (route: 'home' | 'about') => void = () => {};
   function closeSettings(): void {
     settingsOpen = false;
   }
+
+  function handleOpenSearch(): void {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const input = document.querySelector<HTMLInputElement>('input[name="quote-search"]');
+    input?.focus();
+  }
 </script>
 
 <div class="app-shell">
@@ -164,7 +219,14 @@ export let navigateTo: (route: 'home' | 'about') => void = () => {};
 
   <main class="relative z-[100] flex flex-1 flex-col gap-8 py-14">
     <section class="app-surface">
-      <HeaderBar {quote} onOpenSettings={openSettings} />
+      <HeaderBar
+        {quote}
+        quoteIndex={quote?.index ?? 0}
+        quoteTotal={quote?.total ?? 0}
+        autoAdvanceProgress={autoAdvanceProgress}
+        on:openSettings={openSettings}
+        on:openSearch={handleOpenSearch}
+      />
       <QuoteSearch />
       <QuoteCard {quote} />
       <ControlsBar {quote} />

--- a/src/app/components/FlipClock.svelte
+++ b/src/app/components/FlipClock.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+
+  export let use12Hour = true;
+
+  let now = new Date();
+  let ticker: ReturnType<typeof setInterval> | null = null;
+
+  function update(): void {
+    now = new Date();
+  }
+
+  onMount(() => {
+    update();
+    ticker = setInterval(update, 1000);
+  });
+
+  onDestroy(() => {
+    if (ticker) {
+      clearInterval(ticker);
+      ticker = null;
+    }
+  });
+
+  function toDigits(value: number): [string, string] {
+    const padded = value.toString().padStart(2, '0');
+    return [padded[0], padded[1]];
+  }
+
+  $: hoursRaw = now.getHours();
+  $: hours = use12Hour ? ((hoursRaw + 11) % 12) + 1 : hoursRaw;
+  $: minutes = now.getMinutes();
+  $: seconds = now.getSeconds();
+  $: ampm = use12Hour ? (hoursRaw >= 12 ? 'PM' : 'AM') : '';
+
+  $: [hourTens, hourOnes] = toDigits(hours);
+  $: [minuteTens, minuteOnes] = toDigits(minutes);
+  $: [secondTens, secondOnes] = toDigits(seconds);
+</script>
+
+<div class="flip-clock" role="timer" aria-live="polite" aria-atomic="true">
+  <div class="flip-group">
+    <div class="flip-unit" aria-label={`Hours ${hours}`}>
+      <span class="flip-digit">{hourTens}</span>
+      <span class="flip-digit">{hourOnes}</span>
+    </div>
+
+    <span class="colon" aria-hidden="true">:</span>
+
+    <div class="flip-unit" aria-label={`Minutes ${minutes}`}>
+      <span class="flip-digit">{minuteTens}</span>
+      <span class="flip-digit">{minuteOnes}</span>
+    </div>
+
+    <span class="colon" aria-hidden="true">:</span>
+
+    <div class="flip-unit" aria-label={`Seconds ${seconds}`}>
+      <span class="flip-digit">{secondTens}</span>
+      <span class="flip-digit">{secondOnes}</span>
+    </div>
+  </div>
+
+  {#if ampm}
+    <span class="ampm" aria-hidden="true">{ampm}</span>
+  {/if}
+</div>
+
+<style>
+  .flip-clock {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    color: white;
+  }
+
+  .flip-group {
+    display: flex;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .flip-unit {
+    display: inline-flex;
+    align-items: stretch;
+    gap: 0.25rem;
+  }
+
+  .flip-digit {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.75rem;
+    height: 3.5rem;
+    padding: 0.15rem 0.35rem;
+    font-size: 2.25rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    border-radius: 0.65rem;
+    position: relative;
+    background: radial-gradient(circle at top, rgba(255, 255, 255, 0.12), rgba(15, 23, 42, 0.65));
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.2),
+      inset 0 -2px 12px rgba(56, 189, 248, 0.35),
+      0 12px 24px rgba(15, 23, 42, 0.5);
+    text-shadow: 0 0 18px rgba(236, 72, 153, 0.65);
+  }
+
+  .flip-digit::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0),
+      rgba(255, 255, 255, 0.45),
+      rgba(255, 255, 255, 0)
+    );
+    transform: translateY(-50%);
+    opacity: 0.8;
+  }
+
+  .flip-digit::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(
+      180deg,
+      rgba(56, 189, 248, 0.08),
+      rgba(236, 72, 153, 0.12)
+    );
+    opacity: 0.8;
+    mix-blend-mode: screen;
+  }
+
+  .colon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2.2rem;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.7);
+    text-shadow: 0 0 12px rgba(56, 189, 248, 0.55);
+  }
+
+  .ampm {
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  @media (max-width: 640px) {
+    .flip-digit {
+      min-width: 2.2rem;
+      height: 2.8rem;
+      font-size: 1.75rem;
+    }
+
+    .colon {
+      font-size: 1.8rem;
+    }
+  }
+</style>

--- a/src/app/components/HeaderBar.svelte
+++ b/src/app/components/HeaderBar.svelte
@@ -1,82 +1,184 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
   import { FontAwesomeIcon as Fa } from '@fortawesome/svelte-fontawesome';
-  import { faBookmark, faGear } from '@fortawesome/free-solid-svg-icons';
-  import ThemeToggle from './ThemeToggle.svelte';
-  import { openFavorites } from '../stores/favorites';
+  import { faGear, faMagnifyingGlass, faMoon } from '@fortawesome/free-solid-svg-icons';
+  import HeroDateStamp from './HeroDateStamp.svelte';
+  import HeroProgressBar from './HeroProgressBar.svelte';
+  import FlipClock from './FlipClock.svelte';
+  import { nextTheme } from '../../features/theme';
   import type { QuoteViewModel } from '../stores/quote';
 
+  const dispatch = createEventDispatcher<{ openSearch: void; openSettings: void }>();
+
   export let quote: QuoteViewModel | null = null;
-  export let onOpenSettings: () => void = () => {};
+  export let quoteIndex = 0;
+  export let quoteTotal = 0;
+  export let autoAdvanceProgress = 0;
 
-  let favoritesButton: HTMLButtonElement | null = null;
+  $: message = quote ? 'Tune into your next vibe.' : 'Preparing your first vibe...';
 
-  function handleFavorites(): void {
-    openFavorites(favoritesButton ?? undefined);
+  function handleTheme(): void {
+    nextTheme();
+  }
+
+  function handleSearch(): void {
+    dispatch('openSearch');
+  }
+
+  function handleSettings(): void {
+    dispatch('openSettings');
   }
 </script>
 
-<header class="flex flex-wrap items-center justify-between gap-4 text-white">
-  <div>
-    <div class="header-title-container">
-      <h1 class="title-vibe">Vibe</h1>
-      <h1 class="title-me">Me</h1>
+<header class="hero-header text-white">
+  <div class="status-row">
+    <HeroDateStamp />
+
+    <div class="action-pill" role="group" aria-label="Quick actions">
+      <button
+        type="button"
+        class="pill-button"
+        aria-label="Cycle theme"
+        on:click={handleTheme}
+      >
+        <Fa icon={faMoon} class="h-4 w-4" />
+      </button>
+
+      <button
+        type="button"
+        class="pill-button"
+        aria-label="Open search"
+        on:click={handleSearch}
+      >
+        <Fa icon={faMagnifyingGlass} class="h-4 w-4" />
+      </button>
+
+      <button
+        type="button"
+        class="pill-button"
+        aria-label="Open settings"
+        on:click={handleSettings}
+      >
+        <Fa icon={faGear} class="h-4 w-4" />
+      </button>
     </div>
-    <p class="tagline">
-      {quote ? 'Tune into your next vibe.' : 'Preparing your first vibe...'}
-    </p>
   </div>
 
-  <div class="flex items-center gap-2">
-    <ThemeToggle />
+  <div class="hero-core">
+    <div class="wordmark" aria-label="VibeMe">
+      <span class="wordmark-vibe">Vibe</span>
+      <span class="wordmark-me">Me</span>
+    </div>
 
-    <button
-      type="button"
-      class="rounded-full bg-white/10 p-2 text-white transition hover:bg-white/20"
-      aria-label="Open favorites"
-      bind:this={favoritesButton}
-      on:click={handleFavorites}
-    >
-      <Fa icon={faBookmark} class="h-4 w-4" />
-    </button>
+    <HeroProgressBar {quoteIndex} {quoteTotal} autoAdvanceProgress={autoAdvanceProgress} message={message} />
 
-    <button
-      type="button"
-      class="rounded-full bg-white/10 p-2 text-white transition hover:bg-white/20"
-      aria-label="Open settings"
-      on:click={onOpenSettings}
-    >
-      <Fa icon={faGear} class="h-4 w-4" />
-    </button>
+    <FlipClock />
   </div>
 </header>
 
 <style>
-  .header-title-container {
+  .hero-header {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    gap: 2.5rem;
+    padding: 0.5rem 0 1.5rem;
+  }
+
+  .status-row {
+    display: flex;
     align-items: center;
-    padding: 1rem 0;
+    justify-content: space-between;
+    gap: 1rem;
   }
 
-  .title-vibe,
-  .title-me {
-    font-family: 'Courier New', Courier, monospace;
-    font-size: 3rem;
-    font-weight: bold;
-    text-shadow: 0 0 5px rgba(255, 255, 255, 0.5);
+  .action-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.45rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.4);
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.5);
   }
 
-  .title-vibe {
-    color: #ff00ff;
+  .pill-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 2.2rem;
+    width: 2.2rem;
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(135deg, rgba(236, 72, 153, 0.18), rgba(56, 189, 248, 0.25));
+    color: rgba(255, 255, 255, 0.9);
+    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.12),
+      0 8px 18px rgba(79, 70, 229, 0.25);
   }
 
-  .title-me {
-    color: #00ffff;
+  .pill-button:hover,
+  .pill-button:focus-visible {
+    transform: translateY(-1px) scale(1.04);
+    background: linear-gradient(135deg, rgba(236, 72, 153, 0.4), rgba(56, 189, 248, 0.45));
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.2),
+      0 16px 30px rgba(59, 130, 246, 0.3);
   }
 
-  .tagline {
-    margin: 0;
-    font-size: 0.875rem;
-    color: rgba(255, 255, 255, 0.7);
+  .pill-button:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.65);
+    outline-offset: 2px;
+  }
+
+  .hero-core {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+    text-align: center;
+  }
+
+  .wordmark {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    font-size: clamp(3rem, 7vw, 5rem);
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    text-shadow:
+      0 0 14px rgba(56, 189, 248, 0.65),
+      0 0 28px rgba(236, 72, 153, 0.6);
+  }
+
+  .wordmark-vibe {
+    color: #38bdf8;
+  }
+
+  .wordmark-me {
+    color: #ec4899;
+  }
+
+  @media (max-width: 768px) {
+    .hero-header {
+      gap: 2rem;
+    }
+
+    .status-row {
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+    }
+
+    .status-row :global(.date-stamp) {
+      align-items: center;
+    }
+
+    .action-pill {
+      align-self: center;
+    }
   }
 </style>

--- a/src/app/components/HeroDateStamp.svelte
+++ b/src/app/components/HeroDateStamp.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+
+  let now = new Date();
+  let ticker: ReturnType<typeof setInterval> | null = null;
+
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  function update(): void {
+    now = new Date();
+  }
+
+  onMount(() => {
+    update();
+    ticker = setInterval(update, 1000);
+  });
+
+  onDestroy(() => {
+    if (ticker) {
+      clearInterval(ticker);
+      ticker = null;
+    }
+  });
+
+  $: formatted = formatter.format(now);
+</script>
+
+<div class="date-stamp" aria-live="polite" aria-atomic="true">
+  <span class="weekday">{formatted}</span>
+</div>
+
+<style>
+  .date-stamp {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    color: rgba(255, 255, 255, 0.86);
+    font-size: 0.95rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .weekday {
+    font-weight: 600;
+    text-shadow: 0 0 12px rgba(56, 189, 248, 0.45);
+  }
+
+  @media (max-width: 640px) {
+    .date-stamp {
+      font-size: 0.8rem;
+      letter-spacing: 0.05em;
+    }
+  }
+</style>

--- a/src/app/components/HeroProgressBar.svelte
+++ b/src/app/components/HeroProgressBar.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  export let quoteIndex = 0;
+  export let quoteTotal = 0;
+  export let autoAdvanceProgress = 0;
+  export let message = '';
+
+  function clamp(value: number): number {
+    if (Number.isNaN(value) || !Number.isFinite(value)) return 0;
+    if (value < 0) return 0;
+    if (value > 1) return 1;
+    return value;
+  }
+
+  $: normalizedTotal = quoteTotal > 0 ? quoteTotal : 0;
+  $: normalizedIndex = normalizedTotal > 0 ? Math.min(Math.max(quoteIndex, 0), normalizedTotal) : Math.max(0, quoteIndex);
+  $: progress = normalizedTotal > 0 ? clamp(normalizedIndex / normalizedTotal) : 0;
+  $: timerProgress = clamp(autoAdvanceProgress);
+  $: progressLabel = normalizedTotal > 0 ? `${Math.max(1, Math.ceil(normalizedIndex || 1))} / ${normalizedTotal}` : `${Math.max(0, normalizedIndex)}`;
+</script>
+
+<div class="hero-progress">
+  <div class="progress-header">
+    <span class="progress-title">Vibe progression</span>
+    <span class="progress-count">{progressLabel}</span>
+  </div>
+
+  <div
+    class="progress-track"
+    role="progressbar"
+    aria-valuemin="0"
+    aria-valuemax="{normalizedTotal || 1}"
+    aria-valuenow={normalizedTotal > 0 ? Math.max(1, Math.ceil(normalizedIndex || 1)) : normalizedIndex}
+  >
+    <div class="progress-fill" style={`--progress:${progress * 100}%`}></div>
+    <div class="progress-timer" style={`--timer:${timerProgress * 100}%`}></div>
+    <div class="progress-sheen" aria-hidden="true"></div>
+  </div>
+
+  {#if message}
+    <p class="progress-message">{message}</p>
+  {/if}
+</div>
+
+<style>
+  .hero-progress {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+    max-width: 28rem;
+    margin: 0 auto;
+    color: white;
+  }
+
+  .progress-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  .progress-title {
+    font-weight: 600;
+  }
+
+  .progress-count {
+    font-weight: 700;
+  }
+
+  .progress-track {
+    position: relative;
+    height: 0.85rem;
+    border-radius: 999px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.08);
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.12),
+      0 18px 38px rgba(15, 23, 42, 0.45);
+  }
+
+  .progress-fill {
+    position: absolute;
+    inset: 0;
+    width: var(--progress, 0%);
+    background: linear-gradient(90deg, rgba(56, 189, 248, 0.85), rgba(236, 72, 153, 0.9));
+    transition: width 0.6s ease;
+  }
+
+  .progress-timer {
+    position: absolute;
+    inset: 0;
+    width: var(--timer, 0%);
+    background: linear-gradient(90deg, rgba(96, 165, 250, 0.45), rgba(236, 72, 153, 0.65));
+    mix-blend-mode: screen;
+    transition: width 0.35s ease;
+  }
+
+  .progress-sheen {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
+    opacity: 0.35;
+    pointer-events: none;
+  }
+
+  .progress-message {
+    margin: 0;
+    font-size: 0.85rem;
+    text-align: center;
+    color: rgba(255, 255, 255, 0.75);
+  }
+
+  @media (max-width: 640px) {
+    .hero-progress {
+      gap: 0.65rem;
+    }
+
+    .progress-header {
+      font-size: 0.75rem;
+      letter-spacing: 0.1em;
+    }
+
+    .progress-track {
+      height: 0.75rem;
+    }
+  }
+</style>

--- a/src/app/components/QuoteSearch.test.ts
+++ b/src/app/components/QuoteSearch.test.ts
@@ -27,7 +27,7 @@ vi.mock('../stores/quote', () => {
     },
     __mockApplyQuoteFilter: mockApplyQuoteFilter,
   };
-}, { virtual: true });
+});
 
 const quoteStores = (await import('../stores/quote')) as unknown as {
   applyQuoteFilter: ReturnType<typeof vi.fn>;

--- a/src/app/stores/quote.test.ts
+++ b/src/app/stores/quote.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { get } from 'svelte/store';
+import type { QuoteFilter } from '../../features/quotes/engine';
 import {
   applyQuoteFilter,
   clearQuoteFilter,
@@ -77,7 +78,7 @@ describe('quote store', () => {
         normalizeFilter({
           category: null,
           search: undefined,
-        }),
+        } as unknown as QuoteFilter),
       ).toBeNull();
     });
   });


### PR DESCRIPTION
## Summary
- replace the header bar with a neon hero layout that includes a date stamp, quick-action pill, progress bar, and flip clock
- add dedicated HeroDateStamp, HeroProgressBar, and FlipClock components that drive live updates and emit header events
- track auto-advance progress in AppShell so quote metadata and timers feed the header visuals, and tidy unit tests for newer Vitest typings

## Testing
- npm run lint
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cca21a0be8832ba56443ff53530b0e