### PR TITLE
Add quote search overlay and header trigger

### DIFF
--- a/src/app/AppShell.svelte
+++ b/src/app/AppShell.svelte
@@ -5,7 +5,7 @@ import MatrixLayer from './features/matrix/MatrixLayer.svelte';
 import ControlsBar from './components/ControlsBar.svelte';
 import HeaderBar from './components/HeaderBar.svelte';
 import QuoteCard from './components/QuoteCard.svelte';
-import QuoteSearch from './components/QuoteSearch.svelte';
+import QuoteSearchOverlay from './components/QuoteSearchOverlay.svelte';
 import FavoritesPanel from './panels/FavoritesPanel.svelte';
 import SettingsPanel from './panels/SettingsPanel.svelte';
 import { currentQuote, ensureInitialQuote, requestNextQuote, type QuoteViewModel } from './stores/quote';
@@ -22,6 +22,7 @@ let mounted = false;
 let speechSupported = false;
 let lastSpeechEnabled = false;
 let autoAdvanceTimer: ReturnType<typeof setTimeout> | null = null;
+let searchOpen = false;
 
 function clearAutoAdvanceTimer(): void {
   if (autoAdvanceTimer) {
@@ -156,6 +157,14 @@ export let navigateTo: (route: 'home' | 'about') => void = () => {};
   function closeSettings(): void {
     settingsOpen = false;
   }
+
+  function openSearch(): void {
+    searchOpen = true;
+  }
+
+  function closeSearch(): void {
+    searchOpen = false;
+  }
 </script>
 
 <div class="app-shell">
@@ -164,8 +173,7 @@ export let navigateTo: (route: 'home' | 'about') => void = () => {};
 
   <main class="relative z-[100] flex flex-1 flex-col gap-8 py-14">
     <section class="app-surface">
-      <HeaderBar {quote} onOpenSettings={openSettings} />
-      <QuoteSearch />
+      <HeaderBar {quote} onOpenSettings={openSettings} on:openSearch={openSearch} />
       <QuoteCard {quote} />
       <ControlsBar {quote} />
     </section>
@@ -185,6 +193,8 @@ export let navigateTo: (route: 'home' | 'about') => void = () => {};
     <p>&copy; {currentYear} Vibe Me. All Rights Reserved.</p>
   </footer>
 </div>
+
+<QuoteSearchOverlay open={searchOpen} on:close={closeSearch} />
 
 <FavoritesPanel />
 <SettingsPanel open={settingsOpen} onClose={closeSettings} />

--- a/src/app/components/HeaderBar.svelte
+++ b/src/app/components/HeaderBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
   import { FontAwesomeIcon as Fa } from '@fortawesome/svelte-fontawesome';
-  import { faBookmark, faGear } from '@fortawesome/free-solid-svg-icons';
+  import { faBookmark, faGear, faSearch } from '@fortawesome/free-solid-svg-icons';
   import ThemeToggle from './ThemeToggle.svelte';
   import { openFavorites } from '../stores/favorites';
   import type { QuoteViewModel } from '../stores/quote';
@@ -9,9 +10,17 @@
   export let onOpenSettings: () => void = () => {};
 
   let favoritesButton: HTMLButtonElement | null = null;
+  let searchButton: HTMLButtonElement | null = null;
+
+  const dispatch = createEventDispatcher<{ openSearch: { trigger: HTMLElement | null } }>();
 
   function handleFavorites(): void {
     openFavorites(favoritesButton ?? undefined);
+  }
+
+  function handleOpenSearch(event: MouseEvent): void {
+    const trigger = searchButton ?? (event.currentTarget instanceof HTMLElement ? event.currentTarget : null);
+    dispatch('openSearch', { trigger });
   }
 </script>
 
@@ -28,6 +37,16 @@
 
   <div class="flex items-center gap-2">
     <ThemeToggle />
+
+    <button
+      type="button"
+      class="rounded-full bg-white/10 p-2 text-white transition hover:bg-white/20"
+      aria-label="Search quotes"
+      bind:this={searchButton}
+      on:click={handleOpenSearch}
+    >
+      <Fa icon={faSearch} class="h-4 w-4" />
+    </button>
 
     <button
       type="button"

--- a/src/app/components/QuoteSearch.svelte
+++ b/src/app/components/QuoteSearch.svelte
@@ -1,15 +1,23 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
+  import { createEventDispatcher, onDestroy } from 'svelte';
   import { FontAwesomeIcon as Fa } from '@fortawesome/svelte-fontawesome';
   import { faCircleXmark, faSearch } from '@fortawesome/free-solid-svg-icons';
   import { applyQuoteFilter, quoteLoading } from '../stores/quote';
 
   const SEARCH_DELAY = 280;
 
+  const dispatch = createEventDispatcher<{
+    submit: { query: string };
+    clear: void;
+  }>();
+
   let query = '';
   let lastApplied: string | null = null;
   let debounceHandle: ReturnType<typeof setTimeout> | null = null;
   let isLoading = false;
+  let searchInput: HTMLInputElement | null = null;
+
+  export { searchInput as inputElement };
 
   $: isLoading = $quoteLoading;
 
@@ -55,16 +63,18 @@
     scheduleSearch(value);
   }
 
-  function handleSubmit(event: Event): void {
+  async function handleSubmit(event: Event): Promise<void> {
     event.preventDefault();
     clearDebounce();
-    void runSearch(query);
+    await runSearch(query);
+    dispatch('submit', { query: query.trim() });
   }
 
-  function handleClear(): void {
+  async function handleClear(): Promise<void> {
     query = '';
     clearDebounce();
-    void runSearch('');
+    await runSearch('');
+    dispatch('clear');
   }
 
   onDestroy(() => {
@@ -89,6 +99,7 @@
       maxlength="100"
       bind:value={query}
       on:input={handleInput}
+      bind:this={searchInput}
     />
 
     {#if isLoading}

--- a/src/app/components/QuoteSearch.test.ts
+++ b/src/app/components/QuoteSearch.test.ts
@@ -110,4 +110,38 @@ describe('QuoteSearch', () => {
     await Promise.resolve();
     expect(queryByText('Searching…')).toBeNull();
   });
+
+  it('emits a submit event after applying the search', async () => {
+    vi.useFakeTimers();
+    const handleSubmit = vi.fn();
+    const { getByPlaceholderText, getByRole } = render(QuoteSearch, {
+      events: { submit: handleSubmit },
+    });
+
+    const input = getByPlaceholderText('Search quotes or authors...') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'focus' } });
+
+    const form = getByRole('search');
+    await fireEvent.submit(form);
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+    expect(handleSubmit.mock.calls[0][0]?.detail).toEqual({ query: 'focus' });
+  });
+
+  it('emits a clear event after clearing the search', async () => {
+    vi.useFakeTimers();
+    const handleClear = vi.fn();
+    const { getByPlaceholderText, getByRole } = render(QuoteSearch, {
+      events: { clear: handleClear },
+    });
+
+    const input = getByPlaceholderText('Search quotes or authors...') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'zen' } });
+    await vi.runAllTimersAsync();
+
+    const clearButton = getByRole('button', { name: /clear search/i });
+    await fireEvent.click(clearButton);
+
+    expect(handleClear).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/app/components/QuoteSearchOverlay.svelte
+++ b/src/app/components/QuoteSearchOverlay.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+  import { createEventDispatcher, tick } from 'svelte';
+  import QuoteSearch from './QuoteSearch.svelte';
+
+  export let open = false;
+
+  const dispatch = createEventDispatcher<{ close: void }>();
+
+  let searchInput: HTMLInputElement | null = null;
+  let previouslyFocused: HTMLElement | null = null;
+  let focusCaptured = false;
+
+  function recordFocusOrigin(): void {
+    if (focusCaptured || typeof document === 'undefined') {
+      return;
+    }
+
+    const activeElement = document.activeElement;
+    previouslyFocused = activeElement instanceof HTMLElement ? activeElement : null;
+    focusCaptured = true;
+  }
+
+  function restoreFocus(): void {
+    if (typeof document === 'undefined') {
+      previouslyFocused = null;
+      focusCaptured = false;
+      return;
+    }
+
+    const target = previouslyFocused;
+    previouslyFocused = null;
+    focusCaptured = false;
+
+    if (target) {
+      tick().then(() => {
+        target.focus();
+      });
+    }
+  }
+
+  $: if (open) {
+    recordFocusOrigin();
+    tick().then(() => {
+      if (!open) return;
+      searchInput?.focus();
+      searchInput?.select();
+    });
+  } else if (focusCaptured) {
+    restoreFocus();
+  }
+
+  function emitClose(): void {
+    dispatch('close');
+  }
+
+  function handleBackdropClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget) {
+      emitClose();
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      emitClose();
+    }
+  }
+
+  function handleSubmit(): void {
+    emitClose();
+  }
+
+  function handleClear(): void {
+    emitClose();
+  }
+</script>
+
+{#if open}
+  <div
+    class="quote-search-overlay"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Search quotes"
+    on:click={handleBackdropClick}
+    on:keydown={handleKeydown}
+    tabindex="-1"
+  >
+    <div class="quote-search-dialog">
+      <QuoteSearch bind:inputElement={searchInput} on:submit={handleSubmit} on:clear={handleClear} />
+    </div>
+  </div>
+{/if}
+
+<style>
+  .quote-search-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1.5rem;
+    background: rgba(15, 23, 42, 0.82);
+    backdrop-filter: blur(12px);
+  }
+
+  .quote-search-dialog {
+    width: min(40rem, 100%);
+    border-radius: 1.5rem;
+    padding: 2.5rem 2rem;
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    box-shadow:
+      0 32px 72px rgba(15, 23, 42, 0.55),
+      0 0 0 1px rgba(255, 255, 255, 0.08);
+  }
+
+  @media (max-width: 640px) {
+    .quote-search-dialog {
+      padding: 2rem 1.5rem;
+      border-radius: 1rem;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- extract the quote search form into a modal-style overlay that focuses the input and dispatches close events on dismiss, submit, or clear
- wire the new overlay through AppShell and update the header search button to open it
- enhance QuoteSearch with exported input bindings and submit/clear events to drive the overlay

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cca21af0ec832b9dd485fb55ae42e8