### PR TITLE
Refine settings experience with anchored popover and new controls

### DIFF
--- a/src/app/AppShell.svelte
+++ b/src/app/AppShell.svelte
@@ -15,6 +15,7 @@ const currentYear = new Date().getFullYear();
 
   let quote: QuoteViewModel | null = null;
 let settingsOpen = false;
+let settingsAnchor: HTMLElement | null = null;
 let autoAdvanceEnabled = false;
 let autoAdvanceInterval = 8;
 let speechEnabled = false;
@@ -97,9 +98,9 @@ export let navigateTo: (route: 'home' | 'about') => void = () => {};
   });
 
   const unsubscribeSettings = settings.subscribe((value) => {
-    autoAdvanceEnabled = value.autoAdvanceEnabled;
-    autoAdvanceInterval = value.autoAdvanceInterval;
-    speechEnabled = value.speechEnabled;
+    autoAdvanceEnabled = value.content.autoAdvanceEnabled;
+    autoAdvanceInterval = value.content.autoAdvanceInterval;
+    speechEnabled = value.general.speechEnabled;
 
     if (!mounted) {
       lastSpeechEnabled = speechEnabled;
@@ -149,12 +150,14 @@ export let navigateTo: (route: 'home' | 'about') => void = () => {};
     unsubscribeSettings();
   });
 
-  function openSettings(): void {
+  function openSettings(opener?: HTMLElement | null): void {
+    settingsAnchor = opener ?? null;
     settingsOpen = true;
   }
 
   function closeSettings(): void {
     settingsOpen = false;
+    settingsAnchor = null;
   }
 </script>
 
@@ -187,7 +190,7 @@ export let navigateTo: (route: 'home' | 'about') => void = () => {};
 </div>
 
 <FavoritesPanel />
-<SettingsPanel open={settingsOpen} onClose={closeSettings} />
+<SettingsPanel open={settingsOpen} anchor={settingsAnchor} onClose={closeSettings} />
 
 <style>
   .app-shell {

--- a/src/app/components/AuraGlow.svelte
+++ b/src/app/components/AuraGlow.svelte
@@ -11,6 +11,10 @@
   let gradient: AuraPaletteEntry['gradient'] = DEFAULT_AURA.gradient;
   let size = DEFAULT_AURA_SETTINGS.size;
   let reducedMotion = false;
+  let auraIntensity = DEFAULT_AURA_SETTINGS.intensity;
+  let vibrancy = 65;
+  let warmth = 50;
+  let mouseGlowIntensity = DEFAULT_AURA_SETTINGS.intensity;
 
   let auraHalo: HTMLDivElement | null = null;
   let mounted = false;
@@ -24,6 +28,11 @@
     const palette = AURA_LOOKUP.get(value.aura.colorKey) ?? DEFAULT_AURA;
     gradient = palette.gradient;
     size = value.aura.size;
+    auraIntensity = value.aura.intensity;
+
+    vibrancy = value.appearance.vibrancy;
+    warmth = value.appearance.warmth;
+    mouseGlowIntensity = value.appearance.mouseGlowIntensity;
 
     const nextReducedMotion = value.matrix.reducedMotion;
     const motionChanged = nextReducedMotion !== reducedMotion;
@@ -152,13 +161,18 @@
   });
 
   $: auraSize = `${size}vmin`;
-  $: auraOpacity = reducedMotion ? 0.42 : 0.78;
+  $: auraSaturation = 0.6 + vibrancy / 100;
+  $: auraWarmth = (warmth - 50) * 1.4;
+  $: auraOpacity = Math.max(
+    0.2,
+    Math.min(1, (reducedMotion ? 0.42 : 0.78) * (mouseGlowIntensity / 100) * (auraIntensity / 100)),
+  );
 </script>
 
 <div
   class="aura-glow"
   aria-hidden="true"
-  style={`--aura-gradient: ${gradient}; --aura-size: ${auraSize}; --aura-opacity: ${auraOpacity};`}
+  style={`--aura-gradient: ${gradient}; --aura-size: ${auraSize}; --aura-opacity: ${auraOpacity}; --aura-saturation: ${auraSaturation}; --aura-warmth: ${auraWarmth}deg;`}
 >
   <div class="aura-glow__halo" bind:this={auraHalo}></div>
 </div>
@@ -180,7 +194,7 @@
     height: var(--aura-size, 110vmin);
     background: var(--aura-gradient);
     border-radius: 9999px;
-    filter: blur(120px);
+    filter: blur(120px) saturate(var(--aura-saturation, 1)) hue-rotate(var(--aura-warmth, 0deg));
     opacity: var(--aura-opacity, 0.78);
     transform: translate3d(
       calc(var(--pointer-x, 50vw) - 50%),

--- a/src/app/components/HeaderBar.svelte
+++ b/src/app/components/HeaderBar.svelte
@@ -6,9 +6,10 @@
   import type { QuoteViewModel } from '../stores/quote';
 
   export let quote: QuoteViewModel | null = null;
-  export let onOpenSettings: () => void = () => {};
+  export let onOpenSettings: (anchor?: HTMLElement | null) => void = () => {};
 
   let favoritesButton: HTMLButtonElement | null = null;
+  let settingsButton: HTMLButtonElement | null = null;
 
   function handleFavorites(): void {
     openFavorites(favoritesButton ?? undefined);
@@ -43,7 +44,8 @@
       type="button"
       class="rounded-full bg-white/10 p-2 text-white transition hover:bg-white/20"
       aria-label="Open settings"
-      on:click={onOpenSettings}
+      bind:this={settingsButton}
+      on:click={() => onOpenSettings(settingsButton)}
     >
       <Fa icon={faGear} class="h-4 w-4" />
     </button>

--- a/src/app/components/Popover.svelte
+++ b/src/app/components/Popover.svelte
@@ -1,0 +1,226 @@
+<script lang="ts">
+  import { createEventDispatcher, onDestroy, onMount, tick } from 'svelte';
+
+  const FOCUSABLE =
+    '[tabindex]:not([tabindex="-1"]),a[href],button:not([disabled]),input:not([disabled]),textarea:not([disabled]),select:not([disabled])';
+
+  export let open = false;
+  export let anchor: HTMLElement | null = null;
+  export let labelledBy: string | undefined = undefined;
+  export let describedBy: string | undefined = undefined;
+  export let returnFocus: HTMLElement | null = null;
+
+  const dispatch = createEventDispatcher<{ close: void }>();
+
+  let panel: HTMLDivElement | null = null;
+  let lastFocused: Element | null = null;
+  let listenersAttached = false;
+
+  interface PositionState {
+    top: number;
+    left: number;
+    originX: 'left' | 'right';
+    originY: 'top' | 'bottom';
+  }
+
+  let position: PositionState = { top: 0, left: 0, originX: 'right', originY: 'top' };
+
+  function attachListeners(): void {
+    if (listenersAttached) return;
+    document.addEventListener('keydown', handleKeydown, true);
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    window.addEventListener('resize', handleViewportChange, true);
+    window.addEventListener('scroll', handleViewportChange, true);
+    listenersAttached = true;
+  }
+
+  function detachListeners(): void {
+    if (!listenersAttached) return;
+    document.removeEventListener('keydown', handleKeydown, true);
+    document.removeEventListener('pointerdown', handlePointerDown, true);
+    window.removeEventListener('resize', handleViewportChange, true);
+    window.removeEventListener('scroll', handleViewportChange, true);
+    listenersAttached = false;
+  }
+
+  function getFocusable(): HTMLElement[] {
+    if (!panel) return [];
+    return Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE)).filter((el) => !el.hasAttribute('disabled'));
+  }
+
+  function focusFirst(): void {
+    const focusable = getFocusable();
+    if (focusable.length > 0) {
+      focusable[0].focus();
+    } else {
+      panel?.focus();
+    }
+  }
+
+  function trapFocus(event: KeyboardEvent): void {
+    if (event.key !== 'Tab' || !panel) return;
+    const focusable = getFocusable();
+    if (!focusable.length) {
+      event.preventDefault();
+      panel.focus();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+
+    if (event.shiftKey) {
+      if (active === first || active === panel) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (!open) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      dispatch('close');
+      return;
+    }
+    trapFocus(event);
+  }
+
+  function handlePointerDown(event: PointerEvent): void {
+    if (!open || !panel) return;
+    const target = event.target as Node | null;
+    if (target && (panel.contains(target) || anchor?.contains(target))) {
+      return;
+    }
+    dispatch('close');
+  }
+
+  function handleViewportChange(): void {
+    updatePosition();
+  }
+
+  function updatePosition(): void {
+    if (!open || !panel) return;
+
+    const gap = 12;
+    const padding = 16;
+    const panelRect = panel.getBoundingClientRect();
+
+    if (!anchor) {
+      const top = Math.max(padding, (window.innerHeight - panelRect.height) / 2);
+      const left = Math.max(padding, window.innerWidth - panelRect.width - padding);
+      position = { top, left, originX: 'right', originY: 'top' };
+      return;
+    }
+
+    const anchorRect = anchor.getBoundingClientRect();
+    let top = anchorRect.bottom + gap;
+    let originY: 'top' | 'bottom' = 'top';
+
+    if (top + panelRect.height > window.innerHeight - padding) {
+      top = Math.max(padding, anchorRect.top - gap - panelRect.height);
+      originY = 'bottom';
+    }
+
+    let left = anchorRect.right - panelRect.width;
+    let originX: 'left' | 'right' = 'right';
+
+    if (left < padding) {
+      left = padding;
+      originX = 'left';
+    }
+
+    const maxLeft = window.innerWidth - panelRect.width - padding;
+    if (left > maxLeft) {
+      left = maxLeft;
+      originX = 'right';
+    }
+
+    position = { top, left, originX, originY };
+  }
+
+  onMount(() => {
+    if (open) {
+      tick().then(() => {
+        updatePosition();
+      });
+    }
+  });
+
+  onDestroy(() => {
+    detachListeners();
+  });
+
+  $: {
+    if (open) {
+      attachListeners();
+      lastFocused = document.activeElement;
+      tick().then(() => {
+        updatePosition();
+        focusFirst();
+      });
+    } else {
+      detachListeners();
+      if (lastFocused instanceof HTMLElement) {
+        (returnFocus ?? lastFocused).focus?.();
+      }
+      lastFocused = null;
+    }
+  }
+
+  $: if (open) {
+    const currentAnchor = anchor;
+    tick().then(() => {
+      if (!open) return;
+      if (currentAnchor !== anchor) {
+        updatePosition();
+        return;
+      }
+      updatePosition();
+    });
+  }
+</script>
+
+{#if open}
+  <div class="popover-layer" role="presentation">
+    <div
+      class="popover-panel"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={labelledBy}
+      aria-describedby={describedBy}
+      tabindex="-1"
+      bind:this={panel}
+      style={`top: ${Math.round(position.top)}px; left: ${Math.round(position.left)}px; transform-origin: ${position.originY} ${position.originX};`}
+    >
+      <slot />
+    </div>
+  </div>
+{/if}
+
+<style>
+  .popover-layer {
+    position: fixed;
+    inset: 0;
+    z-index: 10060;
+    pointer-events: none;
+  }
+
+  .popover-panel {
+    position: absolute;
+    min-width: 320px;
+    max-width: min(380px, calc(100vw - 2rem));
+    background: rgba(15, 23, 42, 0.92);
+    backdrop-filter: blur(20px);
+    border-radius: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 30px 60px -25px rgba(15, 23, 42, 0.7);
+    color: white;
+    pointer-events: auto;
+    outline: none;
+  }
+</style>

--- a/src/app/components/QuoteSearch.test.ts
+++ b/src/app/components/QuoteSearch.test.ts
@@ -27,7 +27,7 @@ vi.mock('../stores/quote', () => {
     },
     __mockApplyQuoteFilter: mockApplyQuoteFilter,
   };
-}, { virtual: true });
+});
 
 const quoteStores = (await import('../stores/quote')) as unknown as {
   applyQuoteFilter: ReturnType<typeof vi.fn>;

--- a/src/app/components/ThemeToggle.svelte
+++ b/src/app/components/ThemeToggle.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { currentTheme, setThemeByKey, themes } from '../../features/theme';
+  import { currentTheme, themes } from '../../features/theme';
+  import { setThemePreset } from '../stores/settings';
 
   type ThemeToggleSize = 'md' | 'sm';
 
@@ -26,7 +27,7 @@
 
   function handleSelect(key: string): void {
     if ($currentTheme.key === key) return;
-    setThemeByKey(key);
+    setThemePreset(key);
   }
 
   $: containerClasses = [containerBase, size === 'sm' ? 'text-[0.7rem]' : 'text-xs', className]

--- a/src/app/components/settings/SelectRow.svelte
+++ b/src/app/components/settings/SelectRow.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  export let label: string;
+  export let description: string | null = null;
+  export let value: string;
+  export let options: { value: string; label: string }[] = [];
+  export let disabled = false;
+
+  const dispatch = createEventDispatcher<{ change: string }>();
+
+  function handleChange(event: Event): void {
+    const select = event.currentTarget instanceof HTMLSelectElement ? event.currentTarget : null;
+    if (!select) return;
+    dispatch('change', select.value);
+  }
+</script>
+
+<div class="select" class:disabled={disabled}>
+  <div class="select__text">
+    <span class="select__label">{label}</span>
+    {#if description}
+      <p class="select__description">{description}</p>
+    {/if}
+    <slot name="description" />
+  </div>
+  <select class="select__control" value={value} disabled={disabled} on:change={handleChange}>
+    {#each options as option (option.value)}
+      <option value={option.value}>{option.label}</option>
+    {/each}
+  </select>
+</div>
+
+<style>
+  .select {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.95rem 1.1rem;
+    border-radius: 1.25rem;
+    background: rgba(148, 163, 184, 0.08);
+    transition: background 150ms ease;
+  }
+
+  .select:not(.disabled):hover {
+    background: rgba(148, 163, 184, 0.14);
+  }
+
+  .select.disabled {
+    opacity: 0.6;
+  }
+
+  .select__text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 0;
+  }
+
+  .select__label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .select__description {
+    font-size: 0.72rem;
+    color: rgba(226, 232, 240, 0.7);
+    line-height: 1.4;
+  }
+
+  .select__control {
+    flex-shrink: 0;
+    min-width: 9.5rem;
+    border-radius: 0.85rem;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    background: rgba(15, 23, 42, 0.6);
+    color: rgba(248, 250, 252, 0.9);
+    padding: 0.45rem 0.75rem;
+    font-size: 0.75rem;
+    letter-spacing: 0.02em;
+  }
+</style>

--- a/src/app/components/settings/SliderRow.svelte
+++ b/src/app/components/settings/SliderRow.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  export let label: string;
+  export let description: string | null = null;
+  export let value = 0;
+  export let min = 0;
+  export let max = 100;
+  export let step = 1;
+  export let disabled = false;
+  export let formatValue: (value: number) => string = (v) => `${Math.round(v)}`;
+
+  const dispatch = createEventDispatcher<{ input: number; change: number }>();
+
+  function parseValue(target: EventTarget | null): number | null {
+    const element = target instanceof HTMLInputElement ? target : null;
+    if (!element) return null;
+    const next = Number.parseFloat(element.value);
+    return Number.isFinite(next) ? next : null;
+  }
+
+  function handleInput(event: Event): void {
+    const next = parseValue(event.currentTarget);
+    if (next === null) return;
+    dispatch('input', next);
+  }
+
+  function handleChange(event: Event): void {
+    const next = parseValue(event.currentTarget);
+    if (next === null) return;
+    dispatch('change', next);
+  }
+</script>
+
+<div class="slider" class:disabled={disabled}>
+  <div class="slider__header">
+    <div class="slider__text">
+      <span class="slider__label">{label}</span>
+      {#if description}
+        <p class="slider__description">{description}</p>
+      {/if}
+      <slot name="description" />
+    </div>
+    <span class="slider__value">{formatValue(value)}</span>
+  </div>
+  <input
+    class="slider__control"
+    type="range"
+    min={min}
+    max={max}
+    step={step}
+    value={value}
+    disabled={disabled}
+    on:input={handleInput}
+    on:change={handleChange}
+  />
+</div>
+
+<style>
+  .slider {
+    padding: 1rem 1.1rem 1.15rem;
+    border-radius: 1.25rem;
+    background: rgba(148, 163, 184, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+    transition: background 150ms ease;
+  }
+
+  .slider:not(.disabled):hover {
+    background: rgba(148, 163, 184, 0.14);
+  }
+
+  .slider.disabled {
+    opacity: 0.6;
+  }
+
+  .slider__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .slider__text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .slider__label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .slider__description {
+    font-size: 0.72rem;
+    color: rgba(226, 232, 240, 0.7);
+    line-height: 1.4;
+  }
+
+  .slider__value {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: rgba(248, 250, 252, 0.85);
+    min-width: 3rem;
+    text-align: right;
+  }
+
+  .slider__control {
+    width: 100%;
+    accent-color: rgba(255, 255, 255, 0.85);
+  }
+</style>

--- a/src/app/components/settings/ToggleRow.svelte
+++ b/src/app/components/settings/ToggleRow.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  export let label: string;
+  export let description: string | null = null;
+  export let checked = false;
+  export let disabled = false;
+
+  const dispatch = createEventDispatcher<{ change: boolean }>();
+
+  function handleChange(event: Event): void {
+    const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
+    if (!input) return;
+    dispatch('change', input.checked);
+  }
+</script>
+
+<label class="row" class:disabled={disabled}>
+  <div class="row__content">
+    <span class="row__label">{label}</span>
+    {#if description}
+      <p class="row__description">{description}</p>
+    {/if}
+    <slot name="description" />
+  </div>
+  <input
+    class="row__control"
+    type="checkbox"
+    checked={checked}
+    disabled={disabled}
+    on:change={handleChange}
+  />
+</label>
+
+<style>
+  .row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.9rem 1.1rem;
+    border-radius: 1.25rem;
+    background: rgba(148, 163, 184, 0.08);
+    transition: background 150ms ease;
+  }
+
+  .row:not(.disabled):hover {
+    background: rgba(148, 163, 184, 0.14);
+  }
+
+  .row.disabled {
+    opacity: 0.6;
+  }
+
+  .row__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 0;
+  }
+
+  .row__label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .row__description {
+    font-size: 0.72rem;
+    color: rgba(226, 232, 240, 0.7);
+    line-height: 1.4;
+  }
+
+  .row__control {
+    accent-color: rgba(255, 255, 255, 0.9);
+    transform: scale(1.05);
+  }
+</style>

--- a/src/app/config/aura.ts
+++ b/src/app/config/aura.ts
@@ -7,12 +7,14 @@ export interface AuraPaletteEntry {
 export interface AuraSettings {
   colorKey: string;
   size: number;
+  intensity: number;
 }
 
 export const AURA_SIZE_MIN = 60;
 export const AURA_SIZE_MAX = 160;
 export const AURA_SIZE_STEP = 5;
 export const DEFAULT_AURA_SIZE = 110;
+export const DEFAULT_AURA_INTENSITY = 80;
 
 export const AURA_PALETTE: AuraPaletteEntry[] = [
   {
@@ -56,4 +58,5 @@ export const AURA_LOOKUP = new Map<string, AuraPaletteEntry>(
 export const DEFAULT_AURA_SETTINGS: AuraSettings = {
   colorKey: DEFAULT_AURA.key,
   size: DEFAULT_AURA_SIZE,
+  intensity: DEFAULT_AURA_INTENSITY,
 };

--- a/src/app/features/matrix/MatrixLayer.svelte
+++ b/src/app/features/matrix/MatrixLayer.svelte
@@ -9,21 +9,41 @@
   let initialized = false;
   let mounted = false;
   let state: AppSettingsState = {
-    matrixEnabled: true,
-    beepEnabled: false,
-    speechEnabled: false,
-    autoAdvanceEnabled: false,
-    autoAdvanceInterval: 8,
+    general: { matrixEnabled: true, beepEnabled: false, speechEnabled: false },
+    content: { autoAdvanceEnabled: false, autoAdvanceInterval: 8, streamDensity: 1, inclusiveLanguage: true },
     matrix: DEFAULTS,
     aura: { ...DEFAULT_AURA_SETTINGS },
+    appearance: {
+      colorHarmonyPreset: DEFAULT_AURA_SETTINGS.colorKey,
+      themePreset: 'synthwave',
+      vibrancy: 65,
+      warmth: 50,
+      accessibilityMode: 'standard',
+      mouseGlowIntensity: DEFAULT_AURA_SETTINGS.intensity,
+    },
+    audio: { chimePreset: 'soft', chimeVolume: 65, voiceStyle: 'ambient', voiceWarmth: 55 },
   };
+
+  function applyDocumentStyles(): void {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    document.documentElement.style.setProperty(
+      '--matrix-opacity-token',
+      state.matrix.visibility.toFixed(2),
+    );
+    document.body.dataset.matrixBlendMode = state.matrix.blendMode;
+  }
 
   function applyState(): void {
     if (!mounted) {
       return;
     }
 
-    const wantsCanvas = state.matrixEnabled && state.matrix.renderMode === RenderMode.Canvas;
+    applyDocumentStyles();
+
+    const wantsCanvas = state.general.matrixEnabled && state.matrix.renderMode === RenderMode.Canvas;
 
     if (wantsCanvas) {
       if (!initialized) {
@@ -54,10 +74,13 @@
       teardownMatrix();
       initialized = false;
     }
+    if (typeof document !== 'undefined') {
+      document.body.dataset.matrixBlendMode = '';
+    }
     unsubscribe();
   });
 </script>
 
-{#if state.matrixEnabled && state.matrix.renderMode === RenderMode.Minimal}
+{#if state.general.matrixEnabled && state.matrix.renderMode === RenderMode.Minimal}
   <AuraGlow />
 {/if}

--- a/src/app/panels/SettingsPanel.svelte
+++ b/src/app/panels/SettingsPanel.svelte
@@ -2,7 +2,11 @@
   import { FontAwesomeIcon as Fa } from '@fortawesome/svelte-fontawesome';
   import { faTimes } from '@fortawesome/free-solid-svg-icons';
   import { onDestroy, onMount } from 'svelte';
-  import { RenderMode } from '../../features/matrix/config';
+  import Popover from '../components/Popover.svelte';
+  import ThemeToggle from '../components/ThemeToggle.svelte';
+  import ToggleRow from '../components/settings/ToggleRow.svelte';
+  import SliderRow from '../components/settings/SliderRow.svelte';
+  import SelectRow from '../components/settings/SelectRow.svelte';
   import {
     AURA_PALETTE,
     AURA_SIZE_MAX,
@@ -12,42 +16,73 @@
   } from '../config/aura';
   import {
     settings,
-    setAuraColor,
-    setAuraSize,
+    setMatrixEnabled,
+    setBeepEnabled,
+    setSpeechEnabled,
     setAutoAdvanceEnabled,
     setAutoAdvanceInterval,
-    setBeepEnabled,
-    setMatrixEnabled,
-    setSpeechEnabled,
+    setAuraColor,
+    setAuraSize,
+    setAuraIntensity,
+    updateAppearanceSettings,
+    updateAudioSettings,
+    updateContentSettings,
     updateMatrixConfig,
+    setMatrixPreset,
+    setThemePreset,
+    setAccessibilityMode,
+    type AppSettingsState,
   } from '../stores/settings';
-  import Modal from '../components/Modal.svelte';
-  import ThemeToggle from '../components/ThemeToggle.svelte';
+  import { DEFAULTS, MATRIX_PRESETS, RenderMode } from '../../features/matrix/config';
+  import { themes } from '../../features/theme';
 
   export let open = false;
+  export let anchor: HTMLElement | null = null;
   export let onClose: () => void = () => {};
 
-  let matrixEnabled = true;
-  let beepEnabled = false;
-  let reducedMotion = false;
-  let speechEnabled = false;
-  let autoAdvanceEnabled = false;
-  let autoAdvanceInterval = 8;
+  type TabKey = 'general' | 'appearance' | 'audio' | 'content';
+
+  const tabs: { key: TabKey; label: string }[] = [
+    { key: 'general', label: 'General' },
+    { key: 'appearance', label: 'Appearance' },
+    { key: 'audio', label: 'Audio' },
+    { key: 'content', label: 'Content' },
+  ];
+
+  const MATRIX_SPEED_MIN = 0.4;
+  const MATRIX_SPEED_MAX = 2;
+  const MATRIX_DENSITY_MIN = 0.5;
+  const MATRIX_DENSITY_MAX = 1.5;
+  const AUTO_ADVANCE_INTERVAL_MIN = 5;
+  const AUTO_ADVANCE_INTERVAL_MAX = 60;
+
+  let activeTab: TabKey = 'general';
   let speechAvailable = false;
-  let renderMode: RenderMode = RenderMode.Canvas;
-  let auraColorKey = DEFAULT_AURA_SETTINGS.colorKey;
-  let auraSize = DEFAULT_AURA_SETTINGS.size;
+
+  let state: AppSettingsState = {
+    general: { matrixEnabled: true, beepEnabled: false, speechEnabled: false },
+    content: { autoAdvanceEnabled: false, autoAdvanceInterval: 8, streamDensity: 1, inclusiveLanguage: true },
+    matrix: {
+      ...DEFAULTS,
+      palette: [...DEFAULTS.palette],
+      characters: [...DEFAULTS.characters],
+    },
+    aura: { ...DEFAULT_AURA_SETTINGS },
+    appearance: {
+      colorHarmonyPreset: DEFAULT_AURA_SETTINGS.colorKey,
+      themePreset: themes[0]?.key ?? 'synthwave',
+      vibrancy: 65,
+      warmth: 50,
+      accessibilityMode: 'standard',
+      mouseGlowIntensity: DEFAULT_AURA_SETTINGS.intensity,
+    },
+    audio: { chimePreset: 'soft', chimeVolume: 65, voiceStyle: 'ambient', voiceWarmth: 55 },
+  };
+
+  let tabRefs: Array<HTMLButtonElement | null> = [];
 
   const unsubscribe = settings.subscribe((value) => {
-    matrixEnabled = value.matrixEnabled;
-    beepEnabled = value.beepEnabled;
-    speechEnabled = value.speechEnabled;
-    autoAdvanceEnabled = value.autoAdvanceEnabled;
-    autoAdvanceInterval = value.autoAdvanceInterval;
-    reducedMotion = value.matrix.reducedMotion;
-    renderMode = value.matrix.renderMode;
-    auraColorKey = value.aura.colorKey;
-    auraSize = value.aura.size;
+    state = value;
   });
 
   onDestroy(() => {
@@ -61,203 +96,518 @@
       typeof SpeechSynthesisUtterance !== 'undefined';
   });
 
-  function handleMatrixChange(event: Event): void {
-    const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
-    if (!input) return;
-    setMatrixEnabled(input.checked);
+  function handleClose(): void {
+    onClose();
   }
 
-  function handleBeepChange(event: Event): void {
-    const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
-    if (!input) return;
-    setBeepEnabled(input.checked);
+  function selectTab(key: TabKey): void {
+    activeTab = key;
   }
 
-  function handleSpeechChange(event: Event): void {
-    const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
-    if (!input) return;
-    setSpeechEnabled(input.checked);
+  function focusTab(index: number): void {
+    tabRefs[index]?.focus();
   }
 
-  function handleAutoAdvanceChange(event: Event): void {
-    const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
-    if (!input) return;
-    setAutoAdvanceEnabled(input.checked);
-  }
-
-  function handleAutoAdvanceIntervalInput(event: Event): void {
-    const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
-    if (!input) return;
-    const next = Number.parseFloat(input.value);
-    if (Number.isFinite(next)) {
-      setAutoAdvanceInterval(next);
+  function handleTabKeydown(event: KeyboardEvent, index: number): void {
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      const nextIndex = (index + 1) % tabs.length;
+      selectTab(tabs[nextIndex].key);
+      focusTab(nextIndex);
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      const prevIndex = (index - 1 + tabs.length) % tabs.length;
+      selectTab(tabs[prevIndex].key);
+      focusTab(prevIndex);
     }
   }
 
-  function handleReducedMotionChange(event: Event): void {
-    const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
-    if (!input) return;
-    updateMatrixConfig({ reducedMotion: input.checked });
+  function toPercent(value: number, min: number, max: number): number {
+    const percent = ((value - min) / (max - min)) * 100;
+    return Math.round(Math.max(0, Math.min(100, percent)));
   }
 
-  function handleRenderModeChange(event: Event): void {
-    const select = event.currentTarget instanceof HTMLSelectElement ? event.currentTarget : null;
-    if (!select) return;
-    const value = (select.value as RenderMode) || RenderMode.Canvas;
-    updateMatrixConfig({ renderMode: value });
+  function fromPercent(percent: number, min: number, max: number): number {
+    const ratio = Math.max(0, Math.min(100, percent)) / 100;
+    return min + ratio * (max - min);
   }
 
-  function handleAuraSizeInput(event: Event): void {
-    const input = event.currentTarget instanceof HTMLInputElement ? event.currentTarget : null;
-    if (!input) return;
-    const next = Number.parseFloat(input.value);
-    if (Number.isFinite(next)) {
-      setAuraSize(next);
-    }
-  }
+  type Option = { value: string; label: string };
+
+  const harmonyOptions: Option[] = AURA_PALETTE.map((swatch) => ({
+    value: swatch.key,
+    label: swatch.label,
+  }));
+
+  const themeOptions: Option[] = themes.map((theme) => ({
+    value: theme.key,
+    label: theme.key
+      .split('-')
+      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join(' '),
+  }));
+
+  const matrixPresetOptions: Option[] = MATRIX_PRESETS.map((preset) => ({
+    value: preset.key,
+    label: preset.label,
+  }));
+
+  const blendModeOptions: Option[] = [
+    { value: 'screen', label: 'Screen glow' },
+    { value: 'lighten', label: 'Lighten blend' },
+    { value: 'difference', label: 'High contrast' },
+  ];
+
+  const renderModeOptions: Option[] = [
+    { value: RenderMode.Canvas, label: 'Animated canvas' },
+    { value: RenderMode.Minimal, label: 'Minimal glow' },
+  ];
+
+  const accessibilityOptions: Option[] = [
+    { value: 'standard', label: 'Standard' },
+    { value: 'contrast', label: 'Contrast boost' },
+    { value: 'calm', label: 'Calm mode' },
+  ];
+
+  const chimePresetOptions: Option[] = [
+    { value: 'soft', label: 'Soft shimmer' },
+    { value: 'bright', label: 'Bright pulse' },
+    { value: 'mute', label: 'Muted' },
+  ];
+
+  const voiceStyleOptions: Option[] = [
+    { value: 'ambient', label: 'Ambient' },
+    { value: 'storyteller', label: 'Storyteller' },
+  ];
 </script>
 
-<Modal open={open} on:close={onClose} labelledBy="settings-title">
-  <div class="flex items-center justify-between border-b border-white/10 px-5 py-4 text-white">
-    <h2 id="settings-title" class="text-sm font-semibold uppercase tracking-wide">Settings</h2>
-    <button
-      type="button"
-      class="rounded-full bg-white/10 p-2 text-white transition hover:bg-white/20"
-      aria-label="Close settings"
-      on:click={onClose}
-    >
-      <Fa icon={faTimes} class="h-4 w-4" />
-    </button>
-  </div>
+<Popover
+  {open}
+  {anchor}
+  labelledBy="settings-title"
+  on:close={handleClose}
+  returnFocus={anchor}
+>
+  <div class="settings-panel">
+    <header class="settings-header">
+      <div class="settings-title">
+        <h2 id="settings-title">Settings</h2>
+        <p>Fine-tune your atmosphere and flow.</p>
+      </div>
+      <button
+        type="button"
+        class="close-button"
+        aria-label="Close settings"
+        on:click={handleClose}
+      >
+        <Fa icon={faTimes} class="h-4 w-4" />
+      </button>
+    </header>
 
-  <div class="space-y-6 px-5 py-4 text-sm text-white/80">
-    <section class="space-y-3">
-      <h3 class="text-xs font-semibold uppercase tracking-wide text-white/60">General</h3>
-      <div class="flex flex-wrap items-center justify-between gap-4 rounded-2xl bg-white/5 px-4 py-3">
-        <div>
-          <span class="text-sm text-white">Theme</span>
-          <p class="text-xs text-white/50">Choose your vibe palette</p>
-        </div>
-        <ThemeToggle size="sm" />
-      </div>
-      <label class="flex items-center justify-between gap-4 rounded-2xl bg-white/5 px-4 py-3">
-        <span>Visual effects</span>
-        <input type="checkbox" checked={matrixEnabled} on:change={handleMatrixChange} />
-      </label>
-      <label class="flex items-center justify-between gap-4 rounded-2xl bg-white/5 px-4 py-3">
-        <span>Sound chime before quotes</span>
-        <input type="checkbox" checked={beepEnabled} on:change={handleBeepChange} />
-      </label>
-      <div class="space-y-2 rounded-2xl bg-white/5 px-4 py-3">
-        <label class="flex items-center justify-between gap-4">
-          <span>Read quotes aloud</span>
-          <input
-            type="checkbox"
-            checked={speechEnabled && speechAvailable}
-            on:change={handleSpeechChange}
-            disabled={!speechAvailable}
-            aria-disabled={!speechAvailable}
-          />
-        </label>
-        {#if !speechAvailable}
-          <p class="text-[0.7rem] text-white/50">
-            Voice playback requires a browser with speech synthesis support.
-          </p>
-        {/if}
-      </div>
-      <div class="space-y-2 rounded-2xl bg-white/5 px-4 py-3">
-        <label class="flex items-center justify-between gap-4">
-          <span>Auto-refresh quotes</span>
-          <input type="checkbox" checked={autoAdvanceEnabled} on:change={handleAutoAdvanceChange} />
-        </label>
-        <div class="text-xs text-white/60">
-          Choose how often a new quote appears automatically.
-        </div>
-        <div class="flex items-center gap-3">
-          <input
-            type="range"
-            class="w-full accent-white/80"
-            min="5"
-            max="60"
-            step="1"
-            value={autoAdvanceInterval}
-            on:input={handleAutoAdvanceIntervalInput}
-            disabled={!autoAdvanceEnabled}
-            aria-disabled={!autoAdvanceEnabled}
-          />
-          <span class="w-16 text-right text-xs font-semibold text-white/70">
-            {autoAdvanceInterval}s
-          </span>
-        </div>
-      </div>
-    </section>
-
-    <section class="space-y-3">
-      <h3 class="text-xs font-semibold uppercase tracking-wide text-white/60">Aura glow</h3>
-      <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
-        {#each AURA_PALETTE as swatch (swatch.key)}
-          <button
-            type="button"
-            class={`group relative overflow-hidden rounded-2xl border bg-slate-900/40 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 ${
-              auraColorKey === swatch.key
-                ? 'border-white/70 ring-2 ring-white/70'
-                : 'border-white/10 hover:border-white/30'
-            }`}
-            style={`background-image: ${swatch.gradient};`}
-            aria-pressed={auraColorKey === swatch.key}
-            on:click={() => setAuraColor(swatch.key)}
-          >
-            <span
-              class="relative z-10 block px-3 py-4 text-center text-xs font-semibold uppercase tracking-wide text-white drop-shadow"
-            >
-              {swatch.label}
-            </span>
-            <span class="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-black/40"></span>
-          </button>
-        {/each}
-      </div>
-
-      <div class="rounded-2xl bg-white/5 px-4 py-3">
-        <div class="flex items-center justify-between text-xs uppercase tracking-wide text-white/60">
-          <label for="aura-size">Aura size</label>
-          <span class="font-semibold text-white/70">{Math.round(auraSize)}</span>
-        </div>
-        <input
-          id="aura-size"
-          type="range"
-          class="mt-3 w-full accent-white/80"
-          min={AURA_SIZE_MIN}
-          max={AURA_SIZE_MAX}
-          step={AURA_SIZE_STEP}
-          value={auraSize}
-          on:input={handleAuraSizeInput}
-        />
-        <p class="mt-2 text-[0.7rem] text-white/50">Fine-tune the glow radius around the interface.</p>
-      </div>
-    </section>
-
-    <section class="space-y-3">
-      <h3 class="text-xs font-semibold uppercase tracking-wide text-white/60">Matrix renderer</h3>
-      <label class="flex items-center justify-between gap-4 rounded-2xl bg-white/5 px-4 py-3">
-        <span>Reduced motion</span>
-        <input type="checkbox" checked={reducedMotion} on:change={handleReducedMotionChange} />
-      </label>
-      <div class="rounded-2xl bg-white/5 px-4 py-3">
-        <label for="matrix-mode" class="block text-xs uppercase tracking-wide text-white/60">Render style</label>
-        <select
-          id="matrix-mode"
-          class="mt-2 w-full rounded-xl bg-slate-900/60 px-3 py-2 text-sm text-white"
-          value={renderMode}
-          on:change={handleRenderModeChange}
+    <div class="tablist" role="tablist" aria-label="Settings sections">
+      {#each tabs as tab, index (tab.key)}
+        <button
+          id={`tab-${tab.key}`}
+          type="button"
+          class={`tab ${tab.key === activeTab ? 'is-active' : ''}`}
+          role="tab"
+          aria-selected={tab.key === activeTab}
+          aria-controls={`panel-${tab.key}`}
+          tabindex={tab.key === activeTab ? 0 : -1}
+          on:click={() => selectTab(tab.key)}
+          on:keydown={(event) => handleTabKeydown(event, index)}
+          bind:this={tabRefs[index]}
         >
-          <option value={RenderMode.Canvas}>Animated canvas</option>
-          <option value={RenderMode.Minimal}>Minimal glow</option>
-        </select>
-      </div>
-    </section>
-  </div>
+          {tab.label}
+        </button>
+      {/each}
+    </div>
 
-  <div class="border-t border-white/10 px-5 py-4 text-xs text-white/50">
-    Changes apply instantly and respect your reduced-motion preference.
+    <div
+      class="tab-panel"
+      role="tabpanel"
+      id={`panel-${activeTab}`}
+      aria-labelledby={`tab-${activeTab}`}
+    >
+      {#if activeTab === 'general'}
+        <div class="section-grid">
+          <div class="card card--horizontal">
+            <div>
+              <h3>Theme preset</h3>
+              <p>Choose the global gradient blend.</p>
+            </div>
+            <ThemeToggle size="sm" />
+          </div>
+
+          <ToggleRow
+            label="Visual effects"
+            description="Show the animated matrix layer across the interface."
+            checked={state.general.matrixEnabled}
+            on:change={(event) => setMatrixEnabled(event.detail)}
+          />
+
+          <SelectRow
+            label="Rendering engine"
+            description="Switch between the immersive canvas and minimal glow backdrops."
+            value={state.matrix.renderMode}
+            options={renderModeOptions}
+            on:change={(event) => updateMatrixConfig({ renderMode: event.detail as RenderMode })}
+          />
+
+          <SelectRow
+            label="Accessibility mode"
+            description="Adjust contrast and interface motion cues."
+            value={state.appearance.accessibilityMode}
+            options={accessibilityOptions}
+            on:change={(event) => setAccessibilityMode(event.detail as typeof state.appearance.accessibilityMode)}
+          />
+        </div>
+      {:else if activeTab === 'appearance'}
+        <div class="section-grid">
+          <SelectRow
+            label="Color harmony"
+            description="Align the glow palette with your current mood."
+            value={state.appearance.colorHarmonyPreset}
+            options={harmonyOptions}
+            on:change={(event) => setAuraColor(event.detail)}
+          />
+
+          <SelectRow
+            label="Theme preset"
+            description="Sync the surface gradients with your chosen palette."
+            value={state.appearance.themePreset}
+            options={themeOptions}
+            on:change={(event) => setThemePreset(event.detail)}
+          />
+
+          <SliderRow
+            label="Glow vibrancy"
+            description="Intensify the aura saturation and presence."
+            value={state.appearance.vibrancy}
+            min={0}
+            max={100}
+            step={1}
+            on:input={(event) => updateAppearanceSettings({ vibrancy: event.detail })}
+          />
+
+          <SliderRow
+            label="Glow warmth"
+            description="Shift the aura temperature toward cool or warm hues."
+            value={state.appearance.warmth}
+            min={0}
+            max={100}
+            step={1}
+            on:input={(event) => updateAppearanceSettings({ warmth: event.detail })}
+          />
+
+          <SliderRow
+            label="Mouse glow intensity"
+            description="Control how bright the halo responds to cursor movement."
+            value={state.appearance.mouseGlowIntensity}
+            min={0}
+            max={100}
+            step={1}
+            on:input={(event) => updateAppearanceSettings({ mouseGlowIntensity: event.detail })}
+          />
+
+          <SliderRow
+            label="Aura size"
+            description="Adjust the radius of the ambient glow."
+            value={state.aura.size}
+            min={AURA_SIZE_MIN}
+            max={AURA_SIZE_MAX}
+            step={AURA_SIZE_STEP}
+            formatValue={(val) => `${Math.round(val)}`}
+            on:input={(event) => setAuraSize(event.detail)}
+          />
+
+          <SliderRow
+            label="Aura intensity"
+            description="Boost the glow opacity for a stronger presence."
+            value={state.aura.intensity}
+            min={0}
+            max={100}
+            step={1}
+            on:input={(event) => setAuraIntensity(event.detail)}
+          />
+
+          <SelectRow
+            label="Matrix preset"
+            description="Swap between curated palettes and glyph sets."
+            value={state.matrix.preset}
+            options={matrixPresetOptions}
+            on:change={(event) => setMatrixPreset(event.detail)}
+          />
+
+          <SelectRow
+            label="Blend mode"
+            description="How the matrix glow interacts with the interface."
+            value={state.matrix.blendMode}
+            options={blendModeOptions}
+            on:change={(event) => updateMatrixConfig({ blendMode: event.detail as typeof state.matrix.blendMode })}
+          />
+
+          <SliderRow
+            label="Matrix visibility"
+            description="Set the overall opacity of the matrix canvas."
+            value={Math.round(state.matrix.visibility * 100)}
+            min={0}
+            max={100}
+            step={1}
+            formatValue={(val) => `${val}%`}
+            on:input={(event) => updateMatrixConfig({ visibility: event.detail / 100 })}
+          />
+
+          <SliderRow
+            label="Matrix intensity"
+            description="Amplify the brightness of individual glyphs."
+            value={Math.round(state.matrix.intensity * 100)}
+            min={0}
+            max={100}
+            step={1}
+            formatValue={(val) => `${val}%`}
+            on:input={(event) => updateMatrixConfig({ intensity: event.detail / 100 })}
+          />
+
+          <SliderRow
+            label="Stream speed"
+            description="Control how quickly glyphs cascade."
+            value={toPercent(state.matrix.speed, MATRIX_SPEED_MIN, MATRIX_SPEED_MAX)}
+            min={0}
+            max={100}
+            step={1}
+            formatValue={(val) => `${Math.round(fromPercent(val, MATRIX_SPEED_MIN, MATRIX_SPEED_MAX) * 10) / 10}x`}
+            on:input={(event) => updateMatrixConfig({ speed: fromPercent(event.detail, MATRIX_SPEED_MIN, MATRIX_SPEED_MAX) })}
+          />
+
+          <SliderRow
+            label="Stream density"
+            description="Adjust how many glyph columns appear on screen."
+            value={toPercent(state.matrix.density, MATRIX_DENSITY_MIN, MATRIX_DENSITY_MAX)}
+            min={0}
+            max={100}
+            step={1}
+            formatValue={(val) => `${fromPercent(val, MATRIX_DENSITY_MIN, MATRIX_DENSITY_MAX).toFixed(2)}x`}
+            on:input={(event) => updateMatrixConfig({ density: fromPercent(event.detail, MATRIX_DENSITY_MIN, MATRIX_DENSITY_MAX) })}
+          />
+        </div>
+      {:else if activeTab === 'audio'}
+        <div class="section-grid">
+          <ToggleRow
+            label="Sound chime"
+            description="Play a subtle tone before each quote."
+            checked={state.general.beepEnabled}
+            on:change={(event) => setBeepEnabled(event.detail)}
+          />
+
+          <ToggleRow
+            label="Read quotes aloud"
+            description={speechAvailable
+              ? 'Enable a narrated voiceover for each quote.'
+              : 'Voice playback requires a browser with speech synthesis support.'}
+            checked={state.general.speechEnabled && speechAvailable}
+            disabled={!speechAvailable}
+            on:change={(event) => setSpeechEnabled(event.detail)}
+          />
+
+          <SelectRow
+            label="Chime preset"
+            description="Choose the tone profile for the quote cue."
+            value={state.audio.chimePreset}
+            options={chimePresetOptions}
+            on:change={(event) => updateAudioSettings({ chimePreset: event.detail as typeof state.audio.chimePreset })}
+          />
+
+          <SliderRow
+            label="Chime volume"
+            description="Set the loudness of notification sounds."
+            value={state.audio.chimeVolume}
+            min={0}
+            max={100}
+            step={1}
+            formatValue={(val) => `${val}%`}
+            on:input={(event) => updateAudioSettings({ chimeVolume: event.detail })}
+          />
+
+          <SelectRow
+            label="Voice style"
+            description="Choose the narration personality."
+            value={state.audio.voiceStyle}
+            options={voiceStyleOptions}
+            on:change={(event) => updateAudioSettings({ voiceStyle: event.detail as typeof state.audio.voiceStyle })}
+          />
+
+          <SliderRow
+            label="Voice warmth"
+            description="Blend between airy and rich vocal tones."
+            value={state.audio.voiceWarmth}
+            min={0}
+            max={100}
+            step={1}
+            formatValue={(val) => `${val}%`}
+            on:input={(event) => updateAudioSettings({ voiceWarmth: event.detail })}
+          />
+        </div>
+      {:else if activeTab === 'content'}
+        <div class="section-grid">
+          <ToggleRow
+            label="Auto-refresh quotes"
+            description="Rotate to a new quote automatically after a delay."
+            checked={state.content.autoAdvanceEnabled}
+            on:change={(event) => setAutoAdvanceEnabled(event.detail)}
+          />
+
+          <SliderRow
+            label="Refresh cadence"
+            description="How often a new quote appears when auto-refresh is enabled."
+            value={state.content.autoAdvanceInterval}
+            min={AUTO_ADVANCE_INTERVAL_MIN}
+            max={AUTO_ADVANCE_INTERVAL_MAX}
+            step={1}
+            formatValue={(val) => `${Math.round(val)}s`}
+            disabled={!state.content.autoAdvanceEnabled}
+            on:input={(event) => setAutoAdvanceInterval(event.detail)}
+          />
+
+          <SliderRow
+            label="Stream density"
+            description="Control how rich each quote batch feels."
+            value={toPercent(state.content.streamDensity, MATRIX_DENSITY_MIN, MATRIX_DENSITY_MAX)}
+            min={0}
+            max={100}
+            step={1}
+            formatValue={(val) => `${fromPercent(val, MATRIX_DENSITY_MIN, MATRIX_DENSITY_MAX).toFixed(2)}x`}
+            on:input={(event) => updateContentSettings({ streamDensity: fromPercent(event.detail, MATRIX_DENSITY_MIN, MATRIX_DENSITY_MAX) })}
+          />
+
+          <ToggleRow
+            label="Inclusive language"
+            description="Favor quotes with inclusive, uplifting language."
+            checked={state.content.inclusiveLanguage}
+            on:change={(event) => updateContentSettings({ inclusiveLanguage: event.detail })}
+          />
+        </div>
+      {/if}
+    </div>
+
+    <footer class="settings-footer">
+      Changes apply instantly and respect your reduced-motion preference.
+    </footer>
   </div>
-</Modal>
+</Popover>
+
+<style>
+  .settings-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding: 1.4rem 1.5rem 1.6rem;
+    min-width: 320px;
+  }
+
+  .settings-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .settings-title h2 {
+    font-size: 1rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-weight: 700;
+  }
+
+  .settings-title p {
+    margin-top: 0.35rem;
+    font-size: 0.78rem;
+    color: rgba(226, 232, 240, 0.7);
+  }
+
+  .close-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.16);
+    color: rgba(248, 250, 252, 0.85);
+    transition: background 150ms ease;
+  }
+
+  .close-button:hover,
+  .close-button:focus-visible {
+    background: rgba(148, 163, 184, 0.32);
+  }
+
+  .tablist {
+    display: flex;
+    gap: 0.4rem;
+    background: rgba(148, 163, 184, 0.12);
+    padding: 0.35rem;
+    border-radius: 999px;
+  }
+
+  .tab {
+    flex: 1;
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 0.45rem 0.75rem;
+    border-radius: 999px;
+    transition: background 150ms ease, color 150ms ease;
+    color: rgba(226, 232, 240, 0.7);
+  }
+
+  .tab.is-active {
+    background: rgba(248, 250, 252, 0.16);
+    color: rgba(248, 250, 252, 0.95);
+  }
+
+  .tab-panel {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .section-grid {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .card {
+    padding: 1rem 1.1rem;
+    border-radius: 1.25rem;
+    background: rgba(148, 163, 184, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .card--horizontal {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .card h3 {
+    font-size: 0.85rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-weight: 600;
+  }
+
+  .card p {
+    font-size: 0.72rem;
+    color: rgba(226, 232, 240, 0.7);
+  }
+
+  .settings-footer {
+    font-size: 0.72rem;
+    color: rgba(226, 232, 240, 0.65);
+    border-top: 1px solid rgba(148, 163, 184, 0.2);
+    padding-top: 0.75rem;
+  }
+</style>

--- a/src/app/stores/quote.test.ts
+++ b/src/app/stores/quote.test.ts
@@ -75,7 +75,7 @@ describe('quote store', () => {
 
       expect(
         normalizeFilter({
-          category: null,
+          category: null as unknown as string,
           search: undefined,
         }),
       ).toBeNull();

--- a/src/app/stores/settings.ts
+++ b/src/app/stores/settings.ts
@@ -1,29 +1,124 @@
 import { writable } from 'svelte/store';
-import { DEFAULTS, type MatrixConfig } from '../../features/matrix/config';
+import {
+  DEFAULTS,
+  DEFAULT_MATRIX_PRESET,
+  MATRIX_PRESET_LOOKUP,
+  RenderMode,
+  type MatrixBlendMode,
+  type MatrixConfig,
+} from '../../features/matrix/config';
+import { getCurrentThemeKey, setThemeByKey } from '../../features/theme';
 import {
   AURA_LOOKUP,
   AURA_SIZE_MAX,
   AURA_SIZE_MIN,
-  DEFAULT_AURA,
   DEFAULT_AURA_SETTINGS,
   type AuraSettings,
 } from '../config/aura';
 
-export interface AppSettingsState {
+export type AccessibilityMode = 'standard' | 'contrast' | 'calm';
+export type AudioChimePreset = 'soft' | 'bright' | 'mute';
+export type VoiceStyle = 'ambient' | 'storyteller';
+
+export interface GeneralSettings {
   matrixEnabled: boolean;
   beepEnabled: boolean;
   speechEnabled: boolean;
+}
+
+export interface AppearanceSettings {
+  colorHarmonyPreset: string;
+  themePreset: string;
+  vibrancy: number;
+  warmth: number;
+  accessibilityMode: AccessibilityMode;
+  mouseGlowIntensity: number;
+}
+
+export interface AudioSettings {
+  chimePreset: AudioChimePreset;
+  chimeVolume: number;
+  voiceStyle: VoiceStyle;
+  voiceWarmth: number;
+}
+
+export interface ContentSettings {
   autoAdvanceEnabled: boolean;
   autoAdvanceInterval: number;
+  streamDensity: number;
+  inclusiveLanguage: boolean;
+}
+
+export interface AppSettingsState {
+  general: GeneralSettings;
   matrix: MatrixConfig;
   aura: AuraSettings;
+  appearance: AppearanceSettings;
+  audio: AudioSettings;
+  content: ContentSettings;
 }
 
 const AUTO_ADVANCE_INTERVAL_MIN = 5;
 const AUTO_ADVANCE_INTERVAL_MAX = 60;
 const DEFAULT_AUTO_ADVANCE_INTERVAL = 8;
+const MATRIX_DENSITY_MIN = 0.5;
+const MATRIX_DENSITY_MAX = 1.5;
+const MATRIX_SPEED_MIN = 0.4;
+const MATRIX_SPEED_MAX = 2;
+const PERCENT_MIN = 0;
+const PERCENT_MAX = 100;
+const FRACTION_MIN = 0;
+const FRACTION_MAX = 1;
 
-const STORAGE_KEY = 'vibeme:settings:v1';
+const STORAGE_KEY = 'vibeme:settings:v2';
+
+const DEFAULT_GENERAL: GeneralSettings = {
+  matrixEnabled: true,
+  beepEnabled: false,
+  speechEnabled: false,
+};
+
+const DEFAULT_CONTENT: ContentSettings = {
+  autoAdvanceEnabled: false,
+  autoAdvanceInterval: DEFAULT_AUTO_ADVANCE_INTERVAL,
+  streamDensity: 1,
+  inclusiveLanguage: true,
+};
+
+const DEFAULT_APPEARANCE_BASE: Omit<AppearanceSettings, 'themePreset'> = {
+  colorHarmonyPreset: DEFAULT_AURA_SETTINGS.colorKey,
+  vibrancy: 65,
+  warmth: 50,
+  accessibilityMode: 'standard',
+  mouseGlowIntensity: DEFAULT_AURA_SETTINGS.intensity,
+};
+
+const DEFAULT_AUDIO: AudioSettings = {
+  chimePreset: 'soft',
+  chimeVolume: 65,
+  voiceStyle: 'ambient',
+  voiceWarmth: 55,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function clampPercent(value: number): number {
+  return clamp(value, PERCENT_MIN, PERCENT_MAX);
+}
+
+function clampFraction(value: number): number {
+  return clamp(value, FRACTION_MIN, FRACTION_MAX);
+}
+
+function clampDensity(value: number): number {
+  return clamp(value, MATRIX_DENSITY_MIN, MATRIX_DENSITY_MAX);
+}
+
+function clampSpeed(value: number): number {
+  return clamp(value, MATRIX_SPEED_MIN, MATRIX_SPEED_MAX);
+}
 
 function resolveReducedMotion(defaultValue: boolean): boolean {
   if (typeof window === 'undefined') return defaultValue;
@@ -34,25 +129,49 @@ function resolveReducedMotion(defaultValue: boolean): boolean {
   }
 }
 
-function resolveInitialState(): AppSettingsState {
-  const baseMatrix: MatrixConfig = {
+function createGeneral(): GeneralSettings {
+  return { ...DEFAULT_GENERAL };
+}
+
+function createContent(): ContentSettings {
+  return { ...DEFAULT_CONTENT };
+}
+
+function createAppearance(): AppearanceSettings {
+  return {
+    ...DEFAULT_APPEARANCE_BASE,
+    themePreset: getCurrentThemeKey(),
+  };
+}
+
+function createAudio(): AudioSettings {
+  return { ...DEFAULT_AUDIO };
+}
+
+function createAura(): AuraSettings {
+  return { ...DEFAULT_AURA_SETTINGS };
+}
+
+function createMatrix(): MatrixConfig {
+  return {
     ...DEFAULTS,
     reducedMotion: resolveReducedMotion(DEFAULTS.reducedMotion),
   };
+}
 
-  const baseAura: AuraSettings = {
-    ...DEFAULT_AURA_SETTINGS,
+function createBaseState(): AppSettingsState {
+  return {
+    general: createGeneral(),
+    matrix: createMatrix(),
+    aura: createAura(),
+    appearance: createAppearance(),
+    audio: createAudio(),
+    content: createContent(),
   };
+}
 
-  const baseState: AppSettingsState = {
-    matrixEnabled: true,
-    beepEnabled: false,
-    speechEnabled: false,
-    autoAdvanceEnabled: false,
-    autoAdvanceInterval: DEFAULT_AUTO_ADVANCE_INTERVAL,
-    matrix: baseMatrix,
-    aura: baseAura,
-  };
+function resolveInitialState(): AppSettingsState {
+  const baseState = createBaseState();
 
   if (typeof window === 'undefined') {
     return baseState;
@@ -69,44 +188,171 @@ function resolveInitialState(): AppSettingsState {
       return baseState;
     }
 
+    const parsedGeneral =
+      (parsed.general && typeof parsed.general === 'object' ? parsed.general : {}) as Partial<GeneralSettings>;
+    const parsedContent =
+      (parsed.content && typeof parsed.content === 'object' ? parsed.content : {}) as Partial<ContentSettings>;
+    const parsedAppearance =
+      (parsed.appearance && typeof parsed.appearance === 'object' ? parsed.appearance : {}) as Partial<AppearanceSettings>;
+    const parsedAudio =
+      (parsed.audio && typeof parsed.audio === 'object' ? parsed.audio : {}) as Partial<AudioSettings>;
+    const parsedMatrix =
+      (parsed.matrix && typeof parsed.matrix === 'object' ? parsed.matrix : {}) as Partial<MatrixConfig>;
     const parsedAura =
-      parsed.aura && typeof parsed.aura === 'object'
-        ? (parsed.aura as Partial<AuraSettings>)
-        : null;
+      (parsed.aura && typeof parsed.aura === 'object' ? parsed.aura : {}) as Partial<AuraSettings>;
 
-    const persistedAuraKey =
-      parsedAura && typeof parsedAura.colorKey === 'string' ? parsedAura.colorKey : baseAura.colorKey;
-    const auraColorKey = AURA_LOOKUP.has(persistedAuraKey) ? persistedAuraKey : baseAura.colorKey;
+    const nextGeneral: GeneralSettings = {
+      matrixEnabled:
+        typeof parsedGeneral.matrixEnabled === 'boolean'
+          ? parsedGeneral.matrixEnabled
+          : baseState.general.matrixEnabled,
+      beepEnabled:
+        typeof parsedGeneral.beepEnabled === 'boolean'
+          ? parsedGeneral.beepEnabled
+          : baseState.general.beepEnabled,
+      speechEnabled:
+        typeof parsedGeneral.speechEnabled === 'boolean'
+          ? parsedGeneral.speechEnabled
+          : baseState.general.speechEnabled,
+    };
 
-    const persistedAuraSize =
-      parsedAura && typeof parsedAura.size === 'number' && Number.isFinite(parsedAura.size)
-        ? clamp(parsedAura.size, AURA_SIZE_MIN, AURA_SIZE_MAX)
-        : baseAura.size;
+    const parsedInterval =
+      typeof parsedContent.autoAdvanceInterval === 'number' && Number.isFinite(parsedContent.autoAdvanceInterval)
+        ? clamp(parsedContent.autoAdvanceInterval, AUTO_ADVANCE_INTERVAL_MIN, AUTO_ADVANCE_INTERVAL_MAX)
+        : baseState.content.autoAdvanceInterval;
 
-    const persistedInterval =
-      typeof parsed.autoAdvanceInterval === 'number' && Number.isFinite(parsed.autoAdvanceInterval)
-        ? clamp(parsed.autoAdvanceInterval, AUTO_ADVANCE_INTERVAL_MIN, AUTO_ADVANCE_INTERVAL_MAX)
-        : baseState.autoAdvanceInterval;
+    const parsedStreamDensity =
+      typeof parsedContent.streamDensity === 'number' && Number.isFinite(parsedContent.streamDensity)
+        ? clampDensity(parsedContent.streamDensity)
+        : baseState.content.streamDensity;
+
+    const nextContent: ContentSettings = {
+      autoAdvanceEnabled:
+        typeof parsedContent.autoAdvanceEnabled === 'boolean'
+          ? parsedContent.autoAdvanceEnabled
+          : baseState.content.autoAdvanceEnabled,
+      autoAdvanceInterval: parsedInterval,
+      streamDensity: parsedStreamDensity,
+      inclusiveLanguage:
+        typeof parsedContent.inclusiveLanguage === 'boolean'
+          ? parsedContent.inclusiveLanguage
+          : baseState.content.inclusiveLanguage,
+    };
+
+    const parsedHarmony =
+      typeof parsedAppearance.colorHarmonyPreset === 'string' ? parsedAppearance.colorHarmonyPreset : undefined;
+    const harmonyKey = parsedHarmony && AURA_LOOKUP.has(parsedHarmony)
+      ? parsedHarmony
+      : baseState.appearance.colorHarmonyPreset;
+
+    const parsedAccessibility =
+      parsedAppearance.accessibilityMode === 'contrast' || parsedAppearance.accessibilityMode === 'calm'
+        ? parsedAppearance.accessibilityMode
+        : 'standard';
+
+    const nextAppearance: AppearanceSettings = {
+      colorHarmonyPreset: harmonyKey,
+      themePreset:
+        typeof parsedAppearance.themePreset === 'string'
+          ? parsedAppearance.themePreset
+          : baseState.appearance.themePreset,
+      vibrancy:
+        typeof parsedAppearance.vibrancy === 'number' && Number.isFinite(parsedAppearance.vibrancy)
+          ? clampPercent(parsedAppearance.vibrancy)
+          : baseState.appearance.vibrancy,
+      warmth:
+        typeof parsedAppearance.warmth === 'number' && Number.isFinite(parsedAppearance.warmth)
+          ? clampPercent(parsedAppearance.warmth)
+          : baseState.appearance.warmth,
+      accessibilityMode: parsedAccessibility,
+      mouseGlowIntensity:
+        typeof parsedAppearance.mouseGlowIntensity === 'number' && Number.isFinite(parsedAppearance.mouseGlowIntensity)
+          ? clampPercent(parsedAppearance.mouseGlowIntensity)
+          : baseState.appearance.mouseGlowIntensity,
+    };
+
+    const nextAudio: AudioSettings = {
+      chimePreset:
+        parsedAudio.chimePreset === 'bright' || parsedAudio.chimePreset === 'mute'
+          ? parsedAudio.chimePreset
+          : baseState.audio.chimePreset,
+      chimeVolume:
+        typeof parsedAudio.chimeVolume === 'number' && Number.isFinite(parsedAudio.chimeVolume)
+          ? clampPercent(parsedAudio.chimeVolume)
+          : baseState.audio.chimeVolume,
+      voiceStyle:
+        parsedAudio.voiceStyle === 'storyteller'
+          ? parsedAudio.voiceStyle
+          : baseState.audio.voiceStyle,
+      voiceWarmth:
+        typeof parsedAudio.voiceWarmth === 'number' && Number.isFinite(parsedAudio.voiceWarmth)
+          ? clampPercent(parsedAudio.voiceWarmth)
+          : baseState.audio.voiceWarmth,
+    };
+
+    const presetKey =
+      typeof parsedMatrix.preset === 'string' && MATRIX_PRESET_LOOKUP.has(parsedMatrix.preset)
+        ? parsedMatrix.preset
+        : baseState.matrix.preset;
+    const preset = MATRIX_PRESET_LOOKUP.get(presetKey) ?? DEFAULT_MATRIX_PRESET;
+
+    const nextMatrix: MatrixConfig = {
+      ...baseState.matrix,
+      ...parsedMatrix,
+      preset: preset.key,
+      palette: Array.isArray(parsedMatrix.palette) && parsedMatrix.palette.length > 0
+        ? [...parsedMatrix.palette]
+        : [...preset.palette],
+      characters: Array.isArray(parsedMatrix.characters) && parsedMatrix.characters.length > 0
+        ? [...parsedMatrix.characters]
+        : [...preset.characters],
+      density:
+        typeof parsedMatrix.density === 'number' && Number.isFinite(parsedMatrix.density)
+          ? clampDensity(parsedMatrix.density)
+          : clampDensity(nextContent.streamDensity),
+      speed:
+        typeof parsedMatrix.speed === 'number' && Number.isFinite(parsedMatrix.speed)
+          ? clampSpeed(parsedMatrix.speed)
+          : baseState.matrix.speed,
+      visibility:
+        typeof parsedMatrix.visibility === 'number' && Number.isFinite(parsedMatrix.visibility)
+          ? clampFraction(parsedMatrix.visibility)
+          : baseState.matrix.visibility,
+      intensity:
+        typeof parsedMatrix.intensity === 'number' && Number.isFinite(parsedMatrix.intensity)
+          ? clampFraction(parsedMatrix.intensity)
+          : baseState.matrix.intensity,
+      blendMode:
+        parsedMatrix.blendMode === 'lighten' || parsedMatrix.blendMode === 'difference'
+          ? parsedMatrix.blendMode
+          : 'screen',
+      renderMode:
+        parsedMatrix.renderMode === RenderMode.Minimal ? RenderMode.Minimal : RenderMode.Canvas,
+      reducedMotion:
+        typeof parsedMatrix.reducedMotion === 'boolean'
+          ? parsedMatrix.reducedMotion
+          : baseState.matrix.reducedMotion,
+    };
+
+    const nextAura: AuraSettings = {
+      colorKey: harmonyKey,
+      size:
+        typeof parsedAura.size === 'number' && Number.isFinite(parsedAura.size)
+          ? clamp(parsedAura.size, AURA_SIZE_MIN, AURA_SIZE_MAX)
+          : baseState.aura.size,
+      intensity:
+        typeof parsedAura.intensity === 'number' && Number.isFinite(parsedAura.intensity)
+          ? clampPercent(parsedAura.intensity)
+          : baseState.aura.intensity,
+    };
 
     return {
-      matrixEnabled:
-        typeof parsed.matrixEnabled === 'boolean' ? parsed.matrixEnabled : baseState.matrixEnabled,
-      beepEnabled: typeof parsed.beepEnabled === 'boolean' ? parsed.beepEnabled : baseState.beepEnabled,
-      speechEnabled:
-        typeof parsed.speechEnabled === 'boolean' ? parsed.speechEnabled : baseState.speechEnabled,
-      autoAdvanceEnabled:
-        typeof parsed.autoAdvanceEnabled === 'boolean'
-          ? parsed.autoAdvanceEnabled
-          : baseState.autoAdvanceEnabled,
-      autoAdvanceInterval: persistedInterval,
-      matrix: {
-        ...baseMatrix,
-        ...(parsed.matrix && typeof parsed.matrix === 'object' ? parsed.matrix : {}),
-      },
-      aura: {
-        colorKey: auraColorKey,
-        size: persistedAuraSize,
-      },
+      general: nextGeneral,
+      matrix: nextMatrix,
+      aura: nextAura,
+      appearance: nextAppearance,
+      audio: nextAudio,
+      content: nextContent,
     };
   } catch (error) {
     console.warn('[settings] failed to load persisted settings', error);
@@ -116,14 +362,13 @@ function resolveInitialState(): AppSettingsState {
 
 const store = writable<AppSettingsState>(resolveInitialState());
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
-
 if (typeof window !== 'undefined') {
   store.subscribe((value) => {
     try {
       window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+      if (typeof document !== 'undefined') {
+        document.body.dataset.accessibilityMode = value.appearance.accessibilityMode;
+      }
     } catch (error) {
       console.warn('[settings] failed to persist settings', error);
     }
@@ -135,27 +380,45 @@ export const settings = {
 };
 
 export function setMatrixEnabled(enabled: boolean): void {
-  store.update((state) => ({ ...state, matrixEnabled: enabled }));
+  store.update((state) => ({
+    ...state,
+    general: { ...state.general, matrixEnabled: enabled },
+  }));
 }
 
 export function toggleMatrixEnabled(): void {
-  store.update((state) => ({ ...state, matrixEnabled: !state.matrixEnabled }));
+  store.update((state) => ({
+    ...state,
+    general: { ...state.general, matrixEnabled: !state.general.matrixEnabled },
+  }));
 }
 
 export function setBeepEnabled(enabled: boolean): void {
-  store.update((state) => ({ ...state, beepEnabled: enabled }));
+  store.update((state) => ({
+    ...state,
+    general: { ...state.general, beepEnabled: enabled },
+  }));
 }
 
 export function toggleBeepEnabled(): void {
-  store.update((state) => ({ ...state, beepEnabled: !state.beepEnabled }));
+  store.update((state) => ({
+    ...state,
+    general: { ...state.general, beepEnabled: !state.general.beepEnabled },
+  }));
 }
 
 export function setSpeechEnabled(enabled: boolean): void {
-  store.update((state) => ({ ...state, speechEnabled: enabled }));
+  store.update((state) => ({
+    ...state,
+    general: { ...state.general, speechEnabled: enabled },
+  }));
 }
 
 export function setAutoAdvanceEnabled(enabled: boolean): void {
-  store.update((state) => ({ ...state, autoAdvanceEnabled: enabled }));
+  store.update((state) => ({
+    ...state,
+    content: { ...state.content, autoAdvanceEnabled: enabled },
+  }));
 }
 
 export function setAutoAdvanceInterval(seconds: number): void {
@@ -166,31 +429,111 @@ export function setAutoAdvanceInterval(seconds: number): void {
   const clamped = clamp(seconds, AUTO_ADVANCE_INTERVAL_MIN, AUTO_ADVANCE_INTERVAL_MAX);
 
   store.update((state) => {
-    if (state.autoAdvanceInterval === clamped) {
+    if (state.content.autoAdvanceInterval === clamped) {
       return state;
     }
 
     return {
       ...state,
-      autoAdvanceInterval: clamped,
+      content: { ...state.content, autoAdvanceInterval: clamped },
+    };
+  });
+}
+
+export function updateContentSettings(patch: Partial<ContentSettings>): void {
+  store.update((state) => {
+    const nextStream =
+      patch.streamDensity !== undefined && Number.isFinite(patch.streamDensity)
+        ? clampDensity(patch.streamDensity)
+        : state.content.streamDensity;
+
+    const nextContent: ContentSettings = {
+      ...state.content,
+      ...patch,
+      streamDensity: nextStream,
+    };
+
+    return {
+      ...state,
+      content: nextContent,
+      matrix: { ...state.matrix, density: nextStream },
     };
   });
 }
 
 export function updateMatrixConfig(patch: Partial<MatrixConfig>): void {
-  store.update((state) => ({
-    ...state,
-    matrix: {
-      ...state.matrix,
-      ...patch,
-    },
-  }));
+  store.update((state) => {
+    const nextDensity =
+      patch.density !== undefined && Number.isFinite(patch.density)
+        ? clampDensity(patch.density)
+        : state.matrix.density;
+    const nextSpeed =
+      patch.speed !== undefined && Number.isFinite(patch.speed) ? clampSpeed(patch.speed) : state.matrix.speed;
+    const nextVisibility =
+      patch.visibility !== undefined && Number.isFinite(patch.visibility)
+        ? clampFraction(patch.visibility)
+        : state.matrix.visibility;
+    const nextIntensity =
+      patch.intensity !== undefined && Number.isFinite(patch.intensity)
+        ? clampFraction(patch.intensity)
+        : state.matrix.intensity;
+    const nextBlend: MatrixBlendMode =
+      patch.blendMode === 'lighten' || patch.blendMode === 'difference' ? patch.blendMode : state.matrix.blendMode;
+    const nextRenderMode =
+      patch.renderMode === RenderMode.Minimal
+        ? RenderMode.Minimal
+        : patch.renderMode === RenderMode.Canvas
+        ? RenderMode.Canvas
+        : state.matrix.renderMode;
+    const nextReducedMotion =
+      typeof patch.reducedMotion === 'boolean' ? patch.reducedMotion : state.matrix.reducedMotion;
+
+    let nextPresetKey = state.matrix.preset;
+    let nextPalette = [...state.matrix.palette];
+    let nextCharacters = [...state.matrix.characters];
+
+    if (patch.preset && MATRIX_PRESET_LOOKUP.has(patch.preset)) {
+      const preset = MATRIX_PRESET_LOOKUP.get(patch.preset) ?? DEFAULT_MATRIX_PRESET;
+      nextPresetKey = preset.key;
+      nextPalette = [...preset.palette];
+      nextCharacters = [...preset.characters];
+    } else {
+      if (patch.palette && Array.isArray(patch.palette) && patch.palette.length > 0) {
+        nextPalette = [...patch.palette];
+      }
+      if (patch.characters && Array.isArray(patch.characters) && patch.characters.length > 0) {
+        nextCharacters = [...patch.characters];
+      }
+    }
+
+    return {
+      ...state,
+      matrix: {
+        ...state.matrix,
+        density: nextDensity,
+        speed: nextSpeed,
+        visibility: nextVisibility,
+        intensity: nextIntensity,
+        blendMode: nextBlend,
+        renderMode: nextRenderMode,
+        reducedMotion: nextReducedMotion,
+        preset: nextPresetKey,
+        palette: nextPalette,
+        characters: nextCharacters,
+      },
+      content: { ...state.content, streamDensity: nextDensity },
+    };
+  });
+}
+
+export function setMatrixPreset(key: string): void {
+  updateMatrixConfig({ preset: key });
 }
 
 export function setAuraColor(colorKey: string): void {
   store.update((state) => {
-    const nextKey = AURA_LOOKUP.has(colorKey) ? colorKey : state.aura.colorKey ?? DEFAULT_AURA.key;
-    if (state.aura.colorKey === nextKey) {
+    const nextKey = AURA_LOOKUP.has(colorKey) ? colorKey : state.aura.colorKey;
+    if (state.aura.colorKey === nextKey && state.appearance.colorHarmonyPreset === nextKey) {
       return state;
     }
 
@@ -199,6 +542,10 @@ export function setAuraColor(colorKey: string): void {
       aura: {
         ...state.aura,
         colorKey: nextKey,
+      },
+      appearance: {
+        ...state.appearance,
+        colorHarmonyPreset: nextKey,
       },
     };
   });
@@ -224,6 +571,119 @@ export function setAuraSize(size: number): void {
       },
     };
   });
+}
+
+export function setAuraIntensity(intensity: number): void {
+  if (!Number.isFinite(intensity)) {
+    return;
+  }
+
+  const clamped = clampPercent(intensity);
+
+  store.update((state) => {
+    if (state.aura.intensity === clamped) {
+      return state;
+    }
+
+    return {
+      ...state,
+      aura: {
+        ...state.aura,
+        intensity: clamped,
+      },
+    };
+  });
+}
+
+export function updateAppearanceSettings(patch: Partial<AppearanceSettings>): void {
+  store.update((state) => {
+    const nextHarmony =
+      patch.colorHarmonyPreset && AURA_LOOKUP.has(patch.colorHarmonyPreset)
+        ? patch.colorHarmonyPreset
+        : state.appearance.colorHarmonyPreset;
+
+    const nextAppearance: AppearanceSettings = {
+      ...state.appearance,
+      ...patch,
+      colorHarmonyPreset: nextHarmony,
+      vibrancy:
+        patch.vibrancy !== undefined && Number.isFinite(patch.vibrancy)
+          ? clampPercent(patch.vibrancy)
+          : state.appearance.vibrancy,
+      warmth:
+        patch.warmth !== undefined && Number.isFinite(patch.warmth)
+          ? clampPercent(patch.warmth)
+          : state.appearance.warmth,
+      mouseGlowIntensity:
+        patch.mouseGlowIntensity !== undefined && Number.isFinite(patch.mouseGlowIntensity)
+          ? clampPercent(patch.mouseGlowIntensity)
+          : state.appearance.mouseGlowIntensity,
+      accessibilityMode:
+        patch.accessibilityMode === 'contrast' || patch.accessibilityMode === 'calm'
+          ? patch.accessibilityMode
+          : patch.accessibilityMode === 'standard'
+          ? 'standard'
+          : state.appearance.accessibilityMode,
+    };
+
+    return {
+      ...state,
+      appearance: nextAppearance,
+      aura: {
+        ...state.aura,
+        colorKey: nextHarmony,
+      },
+    };
+  });
+}
+
+export function updateAudioSettings(patch: Partial<AudioSettings>): void {
+  store.update((state) => {
+    const nextAudio: AudioSettings = {
+      ...state.audio,
+      ...patch,
+      chimeVolume:
+        patch.chimeVolume !== undefined && Number.isFinite(patch.chimeVolume)
+          ? clampPercent(patch.chimeVolume)
+          : state.audio.chimeVolume,
+      voiceWarmth:
+        patch.voiceWarmth !== undefined && Number.isFinite(patch.voiceWarmth)
+          ? clampPercent(patch.voiceWarmth)
+          : state.audio.voiceWarmth,
+      chimePreset:
+        patch.chimePreset === 'bright' || patch.chimePreset === 'mute'
+          ? patch.chimePreset
+          : patch.chimePreset === 'soft'
+          ? 'soft'
+          : state.audio.chimePreset,
+      voiceStyle:
+        patch.voiceStyle === 'storyteller' ? 'storyteller' : patch.voiceStyle === 'ambient' ? 'ambient' : state.audio.voiceStyle,
+    };
+
+    return {
+      ...state,
+      audio: nextAudio,
+    };
+  });
+}
+
+export function setThemePreset(key: string): void {
+  const theme = setThemeByKey(key);
+  if (!theme) {
+    return;
+  }
+
+  store.update((state) => ({
+    ...state,
+    appearance: {
+      ...state.appearance,
+      themePreset: theme.key,
+    },
+  }));
+}
+
+export function setAccessibilityMode(mode: AccessibilityMode): void {
+  updateAppearanceSettings({ accessibilityMode: mode });
 }
 
 export const __testing__ = { resolveInitialState };

--- a/src/features/matrix/config.ts
+++ b/src/features/matrix/config.ts
@@ -3,6 +3,15 @@ export enum RenderMode {
   Minimal = 'minimal',
 }
 
+export type MatrixBlendMode = 'screen' | 'lighten' | 'difference';
+
+export interface MatrixPreset {
+  key: string;
+  label: string;
+  palette: string[];
+  characters: string[];
+}
+
 export interface MatrixConfig {
   renderMode: RenderMode;
   reducedMotion: boolean;
@@ -10,13 +19,48 @@ export interface MatrixConfig {
   speed: number;
   palette: string[];
   characters: string[];
+  visibility: number;
+  intensity: number;
+  blendMode: MatrixBlendMode;
+  preset: string;
 }
+
+export const MATRIX_PRESETS: MatrixPreset[] = [
+  {
+    key: 'aurora-trail',
+    label: 'Aurora trail',
+    palette: ['#22d3ee', '#6366f1', '#f472b6', '#38bdf8'],
+    characters: ['0', '1', 'あ', 'カ', 'ツ', 'ミ', 'ナ', 'シ', 'ホ', 'ネ'],
+  },
+  {
+    key: 'midnight-sonata',
+    label: 'Midnight sonata',
+    palette: ['#818cf8', '#a855f7', '#22d3ee'],
+    characters: ['✦', '✧', '✺', '✽', '✾', '❉', '❋', '❖'],
+  },
+  {
+    key: 'amber-rush',
+    label: 'Amber rush',
+    palette: ['#fb923c', '#f97316', '#facc15'],
+    characters: ['A', 'B', 'C', 'Δ', 'Ξ', 'Ω', 'λ', 'ψ'],
+  },
+];
+
+export const MATRIX_PRESET_LOOKUP = new Map<string, MatrixPreset>(
+  MATRIX_PRESETS.map((preset) => [preset.key, preset]),
+);
+
+export const DEFAULT_MATRIX_PRESET = MATRIX_PRESETS[0];
 
 export const DEFAULTS: MatrixConfig = {
   renderMode: RenderMode.Canvas,
   reducedMotion: false,
   density: 1,
   speed: 1,
-  palette: ['#22d3ee', '#6366f1', '#f472b6', '#38bdf8'],
-  characters: ['0', '1', 'あ', 'カ', 'ツ', 'ミ', 'ナ', 'シ', 'ホ', 'ネ'],
+  palette: DEFAULT_MATRIX_PRESET.palette,
+  characters: DEFAULT_MATRIX_PRESET.characters,
+  visibility: 0.75,
+  intensity: 0.65,
+  blendMode: 'screen',
+  preset: DEFAULT_MATRIX_PRESET.key,
 };

--- a/src/features/matrix/engine.ts
+++ b/src/features/matrix/engine.ts
@@ -51,6 +51,7 @@ class MatrixRenderer {
 
     this.mount();
     this.resize();
+    this.applyDisplaySettings();
     this.seedDrops();
 
     if (!this.running) {
@@ -71,6 +72,7 @@ class MatrixRenderer {
       return;
     }
 
+    this.applyDisplaySettings();
     this.seedDrops();
   }
 
@@ -132,7 +134,8 @@ class MatrixRenderer {
       const drop = this.drops[i];
       const color = palette[i % palette.length];
       ctx.fillStyle = color;
-      ctx.globalAlpha = drop.opacity;
+      const intensity = Math.max(0.2, Math.min(1.6, 0.4 + this.config.intensity * 1.2));
+      ctx.globalAlpha = Math.min(1, drop.opacity * intensity);
       ctx.fillText(drop.glyph, drop.x, drop.y);
       ctx.globalAlpha = 1;
 
@@ -151,6 +154,12 @@ class MatrixRenderer {
     this.canvas.style.display = 'block';
     this.raf = requestAnimationFrame(this.loop);
   };
+
+  private applyDisplaySettings(): void {
+    const visibility = Math.max(0, Math.min(1, this.config.visibility));
+    this.canvas.style.opacity = visibility.toFixed(2);
+    this.canvas.style.mixBlendMode = this.config.blendMode;
+  }
 }
 
 let renderer: MatrixRenderer | null = null;


### PR DESCRIPTION
## Summary
* replace the settings modal with an anchored popover that mirrors the mock’s tabbed layout and reusable field rows
* expand the application settings store, aura configuration and matrix presets to cover appearance, audio and content controls with persistence
* update the matrix and aura renderers plus theme toggle to react to the richer settings in real time while adding the new popover and form components

## Testing
* npm run lint
* npm run check
* npm test

------
https://chatgpt.com/codex/tasks/task_e_68cca223e308832bb58a7b0bd98c1711