### PR TITLE
Fix sidebar auto-hide timing on touch devices

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -4899,6 +4899,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const SIZE_KEY = 'vibeme.railSize';
   const rootStyles = getComputedStyle(root);
   const HIDE_DELAY = parseInt(rootStyles.getPropertyValue('--rail-hide-delay')) || 8000;
+  const DATA_STATE_VISIBLE = 'visible';
+  const DATA_STATE_HIDDEN = 'hidden';
+  const POINTER_TYPE_TOUCH = 'touch';
 
   const announcer = document.createElement('div');
   announcer.setAttribute('aria-live', 'polite');
@@ -4923,8 +4926,10 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   if (pinned) {
     rail.classList.add('show');
-    rail.dataset.state = 'visible';
+    rail.dataset.state = DATA_STATE_VISIBLE;
     pinBtn?.setAttribute('aria-pressed', 'true');
+  } else {
+    rail.dataset.state = DATA_STATE_HIDDEN;
   }
   collapseBtn?.setAttribute('aria-expanded', String(size === 'expanded'));
 
@@ -4933,24 +4938,34 @@ document.addEventListener('DOMContentLoaded', () => {
     target.addEventListener(type, listener, options);
     cleanupFns.push(() => target.removeEventListener(type, listener, options));
   }
+  function getInteractionType(ev) {
+    const type = ev?.type || '';
+    const pointerType = ev?.pointerType || (type.startsWith('touch') ? POINTER_TYPE_TOUCH : undefined);
+    return {
+      isMouseHover: type === 'pointerenter' && pointerType !== POINTER_TYPE_TOUCH,
+      isKeyboardFocus: type === 'focusin',
+      isTouchInteraction: pointerType === POINTER_TYPE_TOUCH
+    };
+  }
+  function cancelHide(){
+    if (hideTimer){
+      clearTimeout(hideTimer);
+      hideTimer = null;
+    }
+  }
   function show(ev){
     rail.classList.add('show');
-    rail.dataset.state = 'visible';
+    rail.dataset.state = DATA_STATE_VISIBLE;
 
-    if (pinned) return;
-
-    const type = ev?.type || '';
-    const pointerType = ev?.pointerType || (type.startsWith('touch') ? 'touch' : undefined);
-    const isMouseHover = type === 'pointerenter' && pointerType !== 'touch';
-    const isKeyboardFocus = type === 'focusin';
-
-    if (isMouseHover || isKeyboardFocus) {
-      clearTimeout(hideTimer);
+    if (pinned) {
+      cancelHide();
       return;
     }
 
-    if (pointerType === 'touch') {
-      clearTimeout(hideTimer);
+    const { isMouseHover, isKeyboardFocus, isTouchInteraction } = getInteractionType(ev);
+
+    if (isMouseHover || isKeyboardFocus || isTouchInteraction) {
+      cancelHide();
       return;
     }
 
@@ -4958,30 +4973,52 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   function hide(){
     rail.classList.remove('show');
-    rail.dataset.state = 'hidden';
+    rail.dataset.state = DATA_STATE_HIDDEN;
+    cancelHide();
   }
   function scheduleHide(){
     if (pinned) return;
-    clearTimeout(hideTimer);
+    cancelHide();
     hideTimer = setTimeout(hide, HIDE_DELAY);
   }
   function destroy(){
-    clearTimeout(hideTimer);
+    cancelHide();
     cleanupFns.forEach(fn => fn());
   }
   window.addEventListener('beforeunload', destroy);
   window.vbRail = { destroy };
 
-  addEvent(hotzone, 'pointerenter', show);
-  addEvent(hotzone, 'touchstart', show);
-  addEvent(hotzone, 'touchend', scheduleHide);
-  addEvent(hotzone, 'pointercancel', scheduleHide);
-  addEvent(hotzone, 'pointerleave', scheduleHide);
-  addEvent(rail, 'pointerenter', show);
-  addEvent(rail, 'touchstart', show);
-  addEvent(rail, 'touchend', scheduleHide);
-  addEvent(rail, 'pointercancel', scheduleHide);
-  addEvent(rail, 'pointerleave', scheduleHide);
+  function handlePointerDown(ev){
+    const { isTouchInteraction } = getInteractionType(ev);
+    if (!isTouchInteraction) return;
+    // Touch interactions rely on pointer events, so show immediately and clear any timers.
+    show(ev);
+  }
+  function handlePointerMove(ev){
+    const { isTouchInteraction } = getInteractionType(ev);
+    if (!isTouchInteraction) return;
+    // A finger gliding on the rail should keep it visible and cancel pending hides.
+    cancelHide();
+  }
+  function handlePointerUp(ev){
+    const { isTouchInteraction } = getInteractionType(ev);
+    if (!isTouchInteraction) return;
+    scheduleHide();
+  }
+  function handlePointerLeave(){
+    scheduleHide();
+  }
+
+  // Rely solely on pointer events so touch and mouse interactions share the same code paths.
+  const pointerTargets = [hotzone, rail];
+  pointerTargets.forEach(target => {
+    addEvent(target, 'pointerenter', show);
+    addEvent(target, 'pointerdown', handlePointerDown);
+    addEvent(target, 'pointermove', handlePointerMove);
+    addEvent(target, 'pointerup', handlePointerUp);
+    addEvent(target, 'pointercancel', handlePointerLeave);
+    addEvent(target, 'pointerleave', handlePointerLeave);
+  });
   addEvent(rail, 'focusin', show);
   addEvent(rail, 'focusout', scheduleHide);
 

--- a/js/main.js
+++ b/js/main.js
@@ -4929,13 +4929,32 @@ document.addEventListener('DOMContentLoaded', () => {
   collapseBtn?.setAttribute('aria-expanded', String(size === 'expanded'));
 
   const cleanupFns = [];
-  function addEvent(target, type, listener){
-    target.addEventListener(type, listener);
-    cleanupFns.push(() => target.removeEventListener(type, listener));
+  function addEvent(target, type, listener, options){
+    target.addEventListener(type, listener, options);
+    cleanupFns.push(() => target.removeEventListener(type, listener, options));
   }
-  function show(){
+  function show(ev){
     rail.classList.add('show');
     rail.dataset.state = 'visible';
+
+    if (pinned) return;
+
+    const type = ev?.type || '';
+    const pointerType = ev?.pointerType || (type.startsWith('touch') ? 'touch' : undefined);
+    const isMouseHover = type === 'pointerenter' && pointerType !== 'touch';
+    const isKeyboardFocus = type === 'focusin';
+
+    if (isMouseHover || isKeyboardFocus) {
+      clearTimeout(hideTimer);
+      return;
+    }
+
+    if (pointerType === 'touch') {
+      clearTimeout(hideTimer);
+      return;
+    }
+
+    scheduleHide();
   }
   function hide(){
     rail.classList.remove('show');
@@ -4954,8 +4973,14 @@ document.addEventListener('DOMContentLoaded', () => {
   window.vbRail = { destroy };
 
   addEvent(hotzone, 'pointerenter', show);
+  addEvent(hotzone, 'touchstart', show);
+  addEvent(hotzone, 'touchend', scheduleHide);
+  addEvent(hotzone, 'pointercancel', scheduleHide);
   addEvent(hotzone, 'pointerleave', scheduleHide);
   addEvent(rail, 'pointerenter', show);
+  addEvent(rail, 'touchstart', show);
+  addEvent(rail, 'touchend', scheduleHide);
+  addEvent(rail, 'pointercancel', scheduleHide);
   addEvent(rail, 'pointerleave', scheduleHide);
   addEvent(rail, 'focusin', show);
   addEvent(rail, 'focusout', scheduleHide);
@@ -4995,6 +5020,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const action = btn.dataset.action;
     if (navigator.vibrate) navigator.vibrate(10);
     document.dispatchEvent(new CustomEvent('rail:action', {detail:{action}}));
+    if (!pinned) scheduleHide();
   });
 
   addEvent(document, 'keydown', (e) => {


### PR DESCRIPTION
## Summary
- ensure the left rail registers touch interactions so the auto-hide timer fires on mobile
- update the helper to support listener options and trigger hide after rail actions when not pinned

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d01d7e5ef8832ba1f17390c996b949