### PR TITLE
Refine share hub hover handling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -568,8 +568,13 @@ body:not(.using-keyboard) *:focus {
   isolation:isolate;
   background: linear-gradient(135deg, var(--color1), var(--color2));
   box-shadow: var(--shadow-md);
-  transition: transform .2s cubic-bezier(.175,.885,.32,1.275), filter .2s ease, box-shadow .2s ease;
+  transition: transform .2s cubic-bezier(.175,.885,.32,1.275), filter .2s ease, box-shadow .2s ease, opacity .2s ease;
   animation: float 6s ease-in-out infinite;
+}
+
+#shareHubBtn.is-open {
+  opacity: 0;
+  pointer-events: none;
 }
 
 /* Animated gradient ring from generate-btn */

--- a/js/main.js
+++ b/js/main.js
@@ -887,7 +887,7 @@ const VibeMe = {
       if (!shareHubBtn || !buttonContainer) return;
 
       shareHubBtn.setAttribute('aria-expanded', 'true');
-      shareHubBtn.style.display = 'none';
+      shareHubBtn.classList.add('is-open');
       buttonContainer.innerHTML = '';
       buttonContainer.setAttribute('aria-hidden', 'false');
       buttonContainer.classList.add('reveal');
@@ -947,7 +947,7 @@ const VibeMe = {
       buttonContainer.setAttribute('aria-hidden', 'true');
       this.clearShareHoverDelay();
       this.cancelShareCollapse();
-      shareHubBtn.style.display = 'inline-flex';
+      shareHubBtn.classList.remove('is-open');
       shareHubBtn.setAttribute('aria-expanded', 'false');
       shareHubBtn.focus();
     },
@@ -973,12 +973,36 @@ const VibeMe = {
 
       this.clearShareHoverDelay();
 
-      this.state.shareHoverDelayTimer = setTimeout(() => {
-        const shareHubBtn = document.getElementById('shareHubBtn');
-        const buttonContainer = document.getElementById('shareFanContainer');
+      const shareHubBtn = document.getElementById('shareHubBtn');
+      const buttonContainer = document.getElementById('shareFanContainer');
 
-        const stillHovering = (shareHubBtn && shareHubBtn.matches(':hover')) ||
-                              (buttonContainer && buttonContainer.matches(':hover'));
+      if (!shareHubBtn || !buttonContainer) return;
+
+      if (!shareHubBtn.classList.contains('is-open')) {
+        return;
+      }
+
+      const related = ev?.relatedTarget || null;
+      const isWithinShareGroup = (node) => {
+        if (!node) return false;
+        if (node === shareHubBtn || node === buttonContainer) return true;
+        if (shareHubBtn.contains(node) || buttonContainer.contains(node)) return true;
+        if (typeof node.closest === 'function') {
+          return Boolean(node.closest('#shareHubBtn, #shareFanContainer'));
+        }
+        return false;
+      };
+
+      if (isWithinShareGroup(related)) {
+        return;
+      }
+
+      this.state.shareHoverDelayTimer = setTimeout(() => {
+        if (!shareHubBtn.classList.contains('is-open')) {
+          return;
+        }
+
+        const stillHovering = shareHubBtn.matches(':hover') || buttonContainer.matches(':hover');
 
         if (!stillHovering) {
           this.scheduleShareCollapse(400);


### PR DESCRIPTION
## Summary
- toggle a dedicated `is-open` state on the share hub instead of removing it from layout
- hide the hub via opacity and pointer-event rules while the fan-out buttons are displayed
- gate share hover leave collapse logic so it only fires when the pointer fully exits the share controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d13247ba4c832b917b7446bb5e6eef