### PR TITLE
Hide inline TTS controls and enlarge quote text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -933,6 +933,10 @@ button:disabled {
 }
 
 /* TTS Inline Controls Polish */
+#tts-inline-controls {
+    display: none !important;
+}
+
 #tts-inline-controls .action-button i {
     font-size: 0.95rem;
     line-height: 1;
@@ -1790,7 +1794,7 @@ button:disabled {
     }
 
     #quote-text {
-        font-size: 1.1rem;
+        font-size: 1.3rem;
     }
 
     #quote-author {

--- a/index.html
+++ b/index.html
@@ -427,7 +427,7 @@
                              aria-live="polite" aria-atomic="true">
                         <blockquote>
                             <p id="quote-text"
-                               class="quote-text-font text-xl sm:text-2xl md:text-3xl mb-4 leading-relaxed dynamic-text-main quote-text-animate">
+                               class="quote-text-font text-2xl sm:text-3xl md:text-4xl mb-4 leading-relaxed dynamic-text-main quote-text-animate">
                                The only way to do great work is to love what you do.
                             </p>
                             <footer>


### PR DESCRIPTION
## Summary
- hide the inline text-to-speech control cluster so the extra speaker and replay buttons no longer display
- enlarge the primary quote typography, including on very small screens, to give the message more prominence

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d13a8acfe4832b8ba129a81fecbca2