### PR TITLE
Fix quote card overflow and share hover timing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -179,6 +179,29 @@ body { min-height: 100dvh; height: 100dvh; overflow: hidden !important; padding:
   overflow: hidden;
 }
 
+@media (max-height: 840px) {
+  .quote-container-inner {
+    max-height: calc(100dvh - 120px);
+  }
+}
+
+@media (max-height: 720px) {
+  .quote-container-inner {
+    max-height: calc(100dvh - 96px);
+    padding-top: var(--spacing-md);
+    padding-bottom: var(--spacing-md);
+  }
+}
+
+@media (max-height: 640px) {
+  .quote-container-inner {
+    max-height: calc(100dvh - 80px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
 /* ===== ACCESSIBILITY ===== */
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
@@ -932,10 +955,9 @@ button:disabled {
     background-color: rgba(255, 255, 255, 0.1);
 }
 
-/* TTS Inline Controls Polish */
-#tts-inline-controls .action-button i {
-    font-size: 0.95rem;
-    line-height: 1;
+/* Product decision: inline TTS controls stay hidden while desktop UI is simplified */
+body[data-inline-tts="off"] #tts-inline-controls {
+    display: none;
 }
 
 /* Enhanced disabled state for stop button */
@@ -1790,7 +1812,7 @@ button:disabled {
     }
 
     #quote-text {
-        font-size: 1.1rem;
+        font-size: 1.3rem;
     }
 
     #quote-author {

--- a/css/style.css
+++ b/css/style.css
@@ -933,6 +933,10 @@ button:disabled {
 }
 
 /* TTS Inline Controls Polish */
+#tts-inline-controls {
+    display: none !important;
+}
+
 #tts-inline-controls .action-button i {
     font-size: 0.95rem;
     line-height: 1;
@@ -1790,7 +1794,7 @@ button:disabled {
     }
 
     #quote-text {
-        font-size: 1.1rem;
+        font-size: 1.3rem;
     }
 
     #quote-author {

--- a/index.html
+++ b/index.html
@@ -427,7 +427,7 @@
                              aria-live="polite" aria-atomic="true">
                         <blockquote>
                             <p id="quote-text"
-                               class="quote-text-font text-xl sm:text-2xl md:text-3xl mb-4 leading-relaxed dynamic-text-main quote-text-animate">
+                               class="quote-text-font text-2xl sm:text-3xl md:text-4xl mb-4 leading-relaxed dynamic-text-main quote-text-animate">
                                The only way to do great work is to love what you do.
                             </p>
                             <footer>

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
     </script>
 </head>
 
-<body class="min-h-screen flex items-center justify-center p-0 gradient-bg">
+<body class="min-h-screen flex items-center justify-center p-0 gradient-bg" data-inline-tts="off">
     <div id="edge-hotzone" aria-hidden="true"></div>
     <nav id="left-rail" role="navigation" aria-label="VibeMe quick actions" data-state="hidden" data-size="expanded">
       <!--
@@ -423,11 +423,11 @@
                     </header>
 
                     <!-- Quote display area -->
-                    <section class="quote-animation-container text-center mb-8 min-h-[120px] md:min-h-[150px]"
+                    <section class="quote-animation-container text-center mb-6 sm:mb-8 min-h-[120px] md:min-h-[150px]"
                              aria-live="polite" aria-atomic="true">
                         <blockquote>
                             <p id="quote-text"
-                               class="quote-text-font text-xl sm:text-2xl md:text-3xl mb-4 leading-relaxed dynamic-text-main quote-text-animate">
+                               class="quote-text-font text-2xl sm:text-3xl md:text-4xl mb-3 sm:mb-4 leading-relaxed dynamic-text-main quote-text-animate">
                                The only way to do great work is to love what you do.
                             </p>
                             <footer>
@@ -438,7 +438,7 @@
                             </footer>
                         </blockquote>
 
-                        <!-- Inline TTS controls (shown only when TTS is supported/enabled) -->
+                        <!-- Inline TTS controls (intentionally kept hidden in desktop layout; see css/style.css) -->
                         <div id="tts-inline-controls" class="flex items-center justify-center space-x-2 mt-4" hidden>
                             <!-- Primary: Speak / Stop toggle -->
                             <button id="tts-toggle-btn" type="button"

--- a/js/main.js
+++ b/js/main.js
@@ -882,7 +882,9 @@ const VibeMe = {
       }
     },
 
-    expandShareButtons: function() {
+    expandShareButtons: function(options = {}) {
+      const { scheduleIdle = true } = options;
+
       this.cancelShareCollapse();
 
       const shareHubBtn = document.getElementById('shareHubBtn');
@@ -920,7 +922,10 @@ const VibeMe = {
       });
 
       setTimeout(() => buttonContainer.classList.remove('reveal'), 320);
-      this.scheduleShareCollapse(this.SHARE_IDLE_COLLAPSE_DELAY);
+
+      if (scheduleIdle) {
+        this.scheduleShareCollapse(this.SHARE_IDLE_COLLAPSE_DELAY);
+      }
     },
 
     collapseShareButtons: function() {
@@ -964,7 +969,7 @@ const VibeMe = {
       this.clearShareHoverDelay();
 
       if (ev?.currentTarget?.id === 'shareHubBtn') {
-        this.expandShareButtons();
+        this.expandShareButtons({ scheduleIdle: false });
       } else {
         this.cancelShareCollapse();
       }
@@ -2324,7 +2329,10 @@ const VibeMe = {
         const shareHubBtn = document.getElementById('shareHubBtn');
         const shareFanContainer = document.getElementById('shareFanContainer');
         if (shareHubBtn) {
-            shareHubBtn.addEventListener('click', () => this.expandShareButtons());
+            shareHubBtn.addEventListener('click', () => {
+                const keepOpenWhileHovered = shareHubBtn.matches(':hover');
+                this.expandShareButtons({ scheduleIdle: !keepOpenWhileHovered });
+            });
             shareHubBtn.addEventListener('pointerenter', (ev) => this.handleShareHoverEnter(ev));
             shareHubBtn.addEventListener('pointerleave', (ev) => this.handleShareHoverLeave(ev));
         }


### PR DESCRIPTION
## Summary
- relax the quote card's height clamp on short viewports, tighten spacing, and add a fallback scroll state so controls stay visible with the larger typography
- keep the inline TTS controls hidden via a declarative body attribute and explain the rationale in the markup/CSS
- defer the share fan-out's idle timer while the trigger is hovered so the buttons stop collapsing under the pointer

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d13a8acfe4832b8ba129a81fecbca2