### PR TITLE
Remove inline TTS controls from quote display

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,22 +438,7 @@
                             </footer>
                         </blockquote>
 
-                        <!-- Inline TTS controls (shown only when TTS is supported/enabled) -->
-                        <div id="tts-inline-controls" class="flex items-center justify-center space-x-2 mt-4" hidden>
-                            <!-- Primary: Speak / Stop toggle -->
-                            <button id="tts-toggle-btn" type="button"
-                                    class="action-button p-2 bg-white/10 hover:bg-white/20 rounded-full"
-                                    aria-label="Read quote aloud" aria-pressed="false" title="Read aloud">
-                              <i class="fas fa-volume-up" aria-hidden="true"></i>
-                            </button>
-
-                            <!-- Secondary: Replay (optional; keep if you want a visible replay) -->
-                            <button id="tts-replay-btn" type="button"
-                                    class="action-button p-2 bg-white/10 hover:bg-white/20 rounded-full"
-                                    aria-label="Replay audio" title="Replay">
-                              <i class="fas fa-rotate-right" aria-hidden="true"></i>
-                            </button>
-                        </div>
+                        <!-- Inline TTS controls removed -->
                     </section>
 
                     <!-- Action buttons -->


### PR DESCRIPTION
## Summary
- remove the inline text-to-speech control buttons from the quote section to hide the unused circular elements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1e589d55c832bac1e4e6c4b24f1ba