### PR TITLE
Hide redundant matrix preset selector on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1052,9 +1052,9 @@ button:disabled {
 }
 
 @media (max-width: 768px) {
-    .binary-column { 
+    .binary-column {
         width: 14px; /* Proper width for tablet fonts */
-        font-size: 12px; 
+        font-size: 12px;
     }
     
     .generate-btn {
@@ -1078,6 +1078,13 @@ button:disabled {
     
     #settings-panel {
         right: 1rem;
+    }
+}
+
+@media (max-width: 767px) {
+    /* Hide redundant mobile matrix preset selector */
+    #matrix-preset-wrapper {
+        display: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- hide the matrix preset wrapper on viewports narrower than 768px to prevent the redundant mobile preset selector from appearing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d20a63b454832ba4906c68457968c3