### PR TITLE
2 Align favorites panel toggle helpers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1528,8 +1528,7 @@ button:disabled {
     overscroll-behavior: contain; 
 }
 
-/* Favorites off-canvas states */
-#favorites-panel.open { transform: translateX(0); }
+/* Favorites toggle quick styling */
 #favorites-toggle { box-shadow: 0 6px 18px rgba(0,0,0,.25); }
 
 /* Favorite item card */
@@ -2016,94 +2015,6 @@ button:disabled {
   z-index:2;                      /* render above .fc-top during the flip */
 }
 
-/* ===== ENHANCED FAVORITES SYSTEM ===== */
-
-/* Favorites Panel States */
-.favorites-panel {
-    transform-origin: bottom right;
-    will-change: transform, opacity;
-}
-
-.favorites-closed {
-    transform: scale(0.85) translateY(20px);
-    opacity: 0;
-    pointer-events: none;
-    visibility: hidden;
-}
-
-.favorites-open {
-    transform: scale(1) translateY(0);
-    opacity: 1;
-    pointer-events: auto;
-    visibility: visible;
-}
-
-.favorites-minimized {
-    transform: scale(0.95) translateY(10px);
-    opacity: 0.7;
-    pointer-events: none;
-    max-height: 60px;
-    overflow: hidden;
-}
-
-/* Enhanced Glass Morphism */
-.favorites-panel::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: 
-        radial-gradient(ellipse at top left, rgba(255,255,255,0.12) 0%, transparent 50%),
-        radial-gradient(ellipse at bottom right, rgba(0,0,0,0.08) 0%, transparent 50%);
-    border-radius: inherit;
-    pointer-events: none;
-}
-
-.favorites-panel::after {
-    content: '';
-    position: absolute;
-    top: 1px;
-    left: 1px;
-    right: 1px;
-    bottom: 1px;
-    background: 
-        linear-gradient(135deg, 
-            rgba(255,255,255,0.02) 0%,
-            rgba(255,255,255,0.05) 50%,
-            rgba(0,0,0,0.02) 100%
-        );
-    border-radius: calc(1rem - 1px);
-    pointer-events: none;
-}
-
-/* Header Styling */
-.favorites-header {
-    position: relative;
-    z-index: 1;
-    background: linear-gradient(180deg, rgba(255,255,255,0.08) 0%, transparent 100%);
-    border-bottom: 1px solid rgba(255,255,255,0.05);
-}
-
-/* Action Buttons */
-.favorites-action-btn {
-    position: relative;
-    z-index: 1;
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-}
-
-.favorites-action-btn:hover {
-    transform: scale(1.05);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-}
-
-.favorites-action-btn:active {
-    transform: scale(0.98);
-}
-
 /* Body Content */
 .favorites-body {
     position: relative;
@@ -2358,25 +2269,7 @@ button:disabled {
     }
 }
 
-/* Panel transitions: only CLOSED and OPEN used */
-#favorites-panel[data-state="open"] {
-  max-height: 80vh;
-  opacity: 1;
-  pointer-events: auto;
-  transform: translateY(0);
-}
-#favorites-panel[data-state="closed"] {
-  max-height: 0;
-  opacity: 0;
-  pointer-events: none;
-  transform: translateY(8px);
-}
-
-/* Hide body entirely when closed (defensive) */
-#favorites-panel[data-state="closed"] .favorites-body { display:none; }
-
-
-/* ===== FAVORITES — theme-aligned glass UI (open/close only) ===== */
+/* ===== FAVORITES — theme-aligned glass UI (data-state driven) ===== */
 .favorites-panel {
   background: linear-gradient(135deg, rgba(15,23,42,0.75), rgba(31,41,55,0.62));
   backdrop-filter: blur(16px) saturate(160%);
@@ -2385,6 +2278,8 @@ button:disabled {
   box-shadow:
     0 8px 30px rgba(0,0,0,0.35),
     0 0 0 1px rgba(255,255,255,0.05) inset;
+  transform-origin: bottom right;
+  will-change: transform, opacity;
   transition: transform var(--transition-medium), opacity var(--transition-medium), max-height var(--transition-medium);
   max-height: 0; opacity: 0; pointer-events: none; transform: translateY(8px);
 }
@@ -2392,6 +2287,14 @@ button:disabled {
   content: ""; position: absolute; inset: -2px; border-radius: inherit;
   background: linear-gradient(135deg, var(--color1), var(--color2), var(--color3));
   filter: blur(14px); opacity: 0.35; z-index: -1; animation: gradient-border-flow 6s linear infinite;
+}
+.favorites-panel::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: calc(1rem - 1px);
+  background: linear-gradient(135deg, rgba(255,255,255,0.02) 0%, rgba(255,255,255,0.05) 50%, rgba(0,0,0,0.02) 100%);
+  pointer-events: none;
 }
 #favorites-panel[data-state="open"]   { max-height: 80vh; opacity: 1; pointer-events: auto; transform: translateY(0); }
 #favorites-panel[data-state="closed"] { max-height: 0;    opacity: 0; pointer-events: none; transform: translateY(8px); }

--- a/js/main.js
+++ b/js/main.js
@@ -4678,6 +4678,35 @@ document.addEventListener('DOMContentLoaded', () => {
 
     apply(state);
 
+    // Expose a small helper so other UI entry points (rail, hamburger, etc.)
+    // can always toggle the panel through the canonical button click. This
+    // keeps aria/data-state attributes in sync with the favorites module.
+    window.VibeMeFavoritesPanel = {
+      get state() {
+        return state;
+      },
+      isOpen() {
+        return state === STATES.OPEN;
+      },
+      open() {
+        if (state !== STATES.OPEN) {
+          apply(STATES.OPEN);
+        }
+        return state === STATES.OPEN;
+      },
+      close() {
+        if (state !== STATES.CLOSED) {
+          apply(STATES.CLOSED);
+        }
+        return state === STATES.CLOSED;
+      },
+      toggle() {
+        if (!toggleBtn) return false;
+        toggleBtn.click();
+        return true;
+      }
+    };
+
     // Toggle open/close
     toggleBtn.addEventListener('click', (e) => { e.stopPropagation(); apply(state === 'open' ? 'closed' : 'open'); });
     btnClose.addEventListener('click', (e) => { e.stopPropagation(); apply('closed'); });
@@ -5195,7 +5224,9 @@ document.addEventListener('DOMContentLoaded', () => {
         VibeMe.updateQuote && VibeMe.updateQuote();
         break;
       case 'fav':
-        document.getElementById('favorites-toggle')?.click();
+        if (!window.VibeMeFavoritesPanel?.toggle?.()) {
+          document.getElementById('favorites-toggle')?.click();
+        }
         break;
       case 'bookmarks':
         console.log('Bookmarks action');


### PR DESCRIPTION
## Summary
- expose a reusable `window.VibeMeFavoritesPanel` helper so auxiliary UI can toggle the favorites panel by reusing the button click logic
- update the rail action handler to call the shared helper and fall back to clicking `#favorites-toggle`
- clean up the favorites CSS to rely exclusively on the `[data-state]` attributes, removing legacy `.open` style hooks

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d288959290832b8f59b948b22a8a91