### PR TITLE
Add mobile left rail trigger

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2827,6 +2827,69 @@ button:disabled {
   z-index: var(--z-popover);
 }
 
+#mobile-rail-trigger {
+  position: fixed;
+  top: 1rem;
+  left: calc(var(--rail-edge-hotzone) + 0.75rem);
+  width: 2.75rem;
+  height: 2.75rem;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(17, 24, 39, 0.55);
+  color: #fff;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.35);
+  z-index: var(--z-tooltip);
+  padding: 0;
+  margin: 0;
+  gap: 0;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  transition: transform var(--transition-medium),
+              background var(--transition-medium),
+              box-shadow var(--transition-medium);
+  touch-action: manipulation;
+}
+
+#mobile-rail-trigger i {
+  font-size: 1.1rem;
+}
+
+#mobile-rail-trigger:hover {
+  transform: translateY(-1px);
+  background: rgba(17, 24, 39, 0.7);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.4);
+}
+
+#mobile-rail-trigger:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.85);
+  outline-offset: 2px;
+}
+
+#mobile-rail-trigger.is-active {
+  background: rgba(59, 130, 246, 0.85);
+  border-color: rgba(147, 197, 253, 0.5);
+  box-shadow: 0 18px 38px rgba(37, 99, 235, 0.4);
+}
+
+#mobile-rail-trigger.is-active:hover {
+  background: rgba(59, 130, 246, 0.95);
+}
+
+@media (max-width: 768px) {
+  #mobile-rail-trigger {
+    display: flex;
+  }
+}
+
+@media (hover: none) {
+  #mobile-rail-trigger:hover {
+    transform: none;
+  }
+}
+
 #left-rail {
   position: fixed;
   top: 50%;

--- a/index.html
+++ b/index.html
@@ -70,6 +70,14 @@
 
 <body class="min-h-screen flex items-center justify-center p-0 gradient-bg">
     <div id="edge-hotzone" aria-hidden="true"></div>
+    <button id="mobile-rail-trigger"
+            type="button"
+            aria-controls="left-rail"
+            aria-expanded="false"
+            aria-label="Open quick actions">
+      <span class="sr-only">Toggle quick actions</span>
+      <i class="fas fa-bars" aria-hidden="true"></i>
+    </button>
     <nav id="left-rail" role="navigation" aria-label="VibeMe quick actions" data-state="hidden" data-size="expanded">
       <!--
       <header class="rail-header">

--- a/js/main.js
+++ b/js/main.js
@@ -4984,6 +4984,7 @@ document.addEventListener('DOMContentLoaded', () => {
 (function(){
   const rail = document.getElementById('left-rail');
   const hotzone = document.getElementById('edge-hotzone');
+  const mobileTrigger = document.getElementById('mobile-rail-trigger');
   if (!rail || !hotzone) return;
 
   const root = document.documentElement;
@@ -5031,6 +5032,14 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   collapseBtn?.setAttribute('aria-expanded', String(size === 'expanded'));
 
+  const setTriggerState = (isOpen) => {
+    if (!mobileTrigger) return;
+    mobileTrigger.setAttribute('aria-expanded', String(isOpen));
+    mobileTrigger.setAttribute('aria-label', isOpen ? 'Close quick actions' : 'Open quick actions');
+    mobileTrigger.classList.toggle('is-active', isOpen);
+  };
+  setTriggerState(rail.dataset.state === DATA_STATE_VISIBLE);
+
   const cleanupFns = [];
   function addEvent(target, type, listener, options){
     target.addEventListener(type, listener, options);
@@ -5054,6 +5063,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function show(ev){
     rail.classList.add('show');
     rail.dataset.state = DATA_STATE_VISIBLE;
+    setTriggerState(true);
 
     if (pinned) {
       cancelHide();
@@ -5072,6 +5082,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function hide(){
     rail.classList.remove('show');
     rail.dataset.state = DATA_STATE_HIDDEN;
+    setTriggerState(false);
     cancelHide();
   }
   function scheduleHide(){
@@ -5131,6 +5142,23 @@ document.addEventListener('DOMContentLoaded', () => {
   addEvent(rail, 'focusin', show);
   addEvent(rail, 'focusout', scheduleHide);
 
+  if (mobileTrigger) {
+    addEvent(mobileTrigger, 'click', (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      const isVisible = rail.dataset.state === DATA_STATE_VISIBLE;
+      if (isVisible) {
+        hide();
+      } else {
+        show(ev);
+        cancelHide();
+      }
+    });
+    addEvent(mobileTrigger, 'touchstart', (ev) => {
+      ev.stopPropagation();
+    }, { passive: true });
+  }
+
   if (pinBtn) addEvent(pinBtn, 'click', () => {
     pinned = !pinned;
     pinBtn.setAttribute('aria-pressed', String(pinned));
@@ -5177,6 +5205,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function handleClickOutside(e) {
     if (pinned) return; // Do nothing if the rail is pinned
     // Hide if the click is not on the rail itself, and not within the hover hotzone
+    if (mobileTrigger && mobileTrigger.contains(e.target)) return;
     if (!rail.contains(e.target) && !hotzone.contains(e.target)) {
       hide();
     }


### PR DESCRIPTION
## Summary
- add a dedicated mobile rail trigger button positioned beyond the left hotzone so touch events reach it
- style the trigger with its own stacking context and active state while syncing aria attributes in the rail controller
- integrate the mobile trigger with existing show/hide logic without affecting desktop hover behaviour

## Testing
- playwright mobile toggle verification script

------
https://chatgpt.com/codex/tasks/task_e_68d28e072874832ba55b3ebc43618e79