### PR TITLE
Ensure left rail pin only persists when control available

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -5048,6 +5048,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const pinBtn = rail.querySelector('.rail-pin');
   const collapseBtn = rail.querySelector('.rail-collapse');
   const defaultBtn = rail.querySelector('.rail-btn');
+  if (!pinBtn && pinned) {
+    pinned = false;
+    try { localStorage.removeItem(PIN_KEY); } catch (e) { console.warn('Failed to clear rail pin state:', e); }
+  }
   if (defaultBtn) {
     defaultBtn.classList.add('active');
     defaultBtn.setAttribute('aria-current', 'page');


### PR DESCRIPTION
## Summary
- clear the persisted left rail pin state when the pin control is missing so the rail starts hidden
- continue to initialize the rail with the corrected pinned value and keep aria attributes in sync

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2974cbe08832b9ae7e3f2e6970cdf