### PR TITLE
Add ambient session guided mode and shareable presets

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -179,6 +179,344 @@ body { min-height: 100dvh; height: 100dvh; overflow: hidden !important; padding:
   overflow: hidden;
 }
 
+.focus-chrome {
+  transition: opacity 0.35s ease, visibility 0.35s ease;
+}
+
+body.ambient-active .focus-chrome {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+body.ambient-active {
+  cursor: url('data:image/svg+xml,%3csvg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="%23ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"%3e%3ccircle cx="12" cy="12" r="3"/%3e%3c/svg%3e') 12 12, auto;
+}
+
+.ambient-session-primary-btn,
+.ambient-session-secondary-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.55rem 1rem;
+  transition: all 0.25s ease;
+  border: none;
+  cursor: pointer;
+}
+
+.ambient-session-primary-btn {
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.95), rgba(59, 130, 246, 0.95));
+  color: #fff;
+  box-shadow: 0 10px 25px rgba(59, 130, 246, 0.25);
+}
+
+.ambient-session-primary-btn:hover {
+  box-shadow: 0 14px 32px rgba(139, 92, 246, 0.35);
+  transform: translateY(-1px);
+}
+
+.ambient-session-secondary-btn {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #f8fafc;
+}
+
+.ambient-session-secondary-btn:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.ambient-duration-btn {
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: #f8fafc;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.ambient-duration-btn:hover,
+.ambient-duration-btn.is-active {
+  background: rgba(139, 92, 246, 0.25);
+  border-color: rgba(139, 92, 246, 0.35);
+  color: #fff;
+}
+
+.ambient-session-quick-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+  border-radius: 999px;
+  padding: 0.55rem 1.2rem;
+  background: rgba(255, 255, 255, 0.12);
+  color: #f9fafb;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  transition: all 0.25s ease;
+}
+
+.ambient-session-quick-btn:hover {
+  background: rgba(139, 92, 246, 0.3);
+  transform: translateY(-1px);
+}
+
+.ambient-session-hud {
+  position: fixed;
+  top: 6rem;
+  right: 1.5rem;
+  z-index: 10005;
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.72);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(18px);
+  color: #f8fafc;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.ambient-session-hud.hidden {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px);
+  pointer-events: none;
+}
+
+.ambient-session-ring {
+  width: 62px;
+  height: 62px;
+}
+
+.ambient-session-ring-bg,
+.ambient-session-ring-progress {
+  fill: none;
+  stroke-width: 6;
+  cx: 60;
+  cy: 60;
+  r: 54;
+}
+
+.ambient-session-ring-bg {
+  stroke: rgba(255, 255, 255, 0.12);
+}
+
+.ambient-session-ring-progress {
+  stroke: rgba(129, 140, 248, 0.95);
+  stroke-linecap: round;
+  stroke-dasharray: 339.292;
+  stroke-dashoffset: 339.292;
+  transform: rotate(-90deg);
+  transform-origin: center;
+  transition: stroke-dashoffset 0.3s ease;
+}
+
+.ambient-session-hud-body {
+  min-width: 80px;
+}
+
+.ambient-session-phase {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin: 0;
+  opacity: 0.8;
+}
+
+.ambient-session-time {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.ambient-session-hud-actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.ambient-session-hud-btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.25s ease;
+}
+
+.ambient-session-hud-btn:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+body.ambient-breathe .ambient-breathe-overlay {
+  display: flex;
+}
+
+.ambient-breathe-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 10004;
+  backdrop-filter: blur(30px);
+  background: rgba(15, 23, 42, 0.45);
+  color: #f8fafc;
+  pointer-events: none;
+  transition: background 0.5s ease;
+}
+
+.ambient-breathe-ring {
+  width: min(40vw, 320px);
+  height: min(40vw, 320px);
+  border-radius: 50%;
+  border: 3px solid rgba(129, 140, 248, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(1.1rem, 2vw, 1.6rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  transition: transform 4s ease-in-out, border-color 0.5s ease;
+}
+
+body[data-breathe-phase="inhale"] .ambient-breathe-ring {
+  transform: scale(1.08);
+  border-color: rgba(96, 165, 250, 0.75);
+}
+
+body[data-breathe-phase="hold"] .ambient-breathe-ring {
+  transform: scale(1.0);
+  border-color: rgba(129, 140, 248, 0.85);
+}
+
+body[data-breathe-phase="exhale"] .ambient-breathe-ring {
+  transform: scale(0.75);
+  border-color: rgba(56, 189, 248, 0.7);
+}
+
+.preset-import-drawer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  z-index: 10006;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.55) 38%, rgba(15, 23, 42, 0.8) 100%);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.preset-import-drawer.is-open {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.preset-import-card {
+  width: min(520px, 92vw);
+  margin-bottom: clamp(1.5rem, 5vw, 3rem);
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: 18px;
+  padding: 1.2rem 1.4rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  transform: translateY(24px);
+  transition: transform 0.35s ease;
+}
+
+.preset-import-drawer.is-open .preset-import-card {
+  transform: translateY(0);
+}
+
+.preset-import-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.8rem;
+  color: #f8fafc;
+}
+
+.preset-import-header h2 {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.preset-import-close {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  cursor: pointer;
+}
+
+.preset-import-preview {
+  background: rgba(30, 41, 59, 0.72);
+  border-radius: 14px;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  color: #e2e8f0;
+  font-size: 0.82rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.preset-preview-swatches {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.preset-preview-swatch {
+  flex: 1;
+  height: 36px;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.3);
+}
+
+.preset-import-meta {
+  display: grid;
+  gap: 0.2rem;
+  font-size: 0.78rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.preset-import-actions {
+  display: flex;
+  gap: 0.7rem;
+  margin-top: 1rem;
+}
+
+@media (max-width: 640px) {
+  .ambient-session-hud {
+    top: auto;
+    bottom: 1.5rem;
+    right: 1.5rem;
+  }
+
+  body.ambient-breathe .ambient-breathe-overlay {
+    backdrop-filter: blur(18px);
+  }
+
+  .ambient-breathe-ring {
+    width: min(70vw, 260px);
+    height: min(70vw, 260px);
+  }
+}
+
 /* ===== ACCESSIBILITY ===== */
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
       <span class="sr-only">Toggle quick actions</span>
       <i class="fas fa-bars" aria-hidden="true"></i>
     </button>
-    <nav id="left-rail" role="navigation" aria-label="VibeMe quick actions" data-state="hidden" data-size="expanded">
+    <nav id="left-rail" role="navigation" aria-label="VibeMe quick actions" data-state="hidden" data-size="expanded" class="focus-chrome">
       <ul class="rail-items">
         <li><a class="rail-btn" href="about.html" data-action="about"     title="About VibeMe"  aria-label="About VibeMe"><i class="fas fa-circle-info" aria-hidden="true"></i><span class="label">About</span></a></li>
       </ul>
@@ -119,7 +119,7 @@
     <canvas id="matrix-canvas" class="matrix-canvas" aria-hidden="true"></canvas>
 
     <!-- Top controls -->
-    <div class="fixed top-4 right-4 z-[10001] flex space-x-2">
+    <div class="fixed top-4 right-4 z-[10001] flex space-x-2 focus-chrome">
         <!-- Dark mode toggle -->
         <button id="dark-mode-toggle" type="button"
                 class="cursor-pointer p-2 rounded-full bg-white/20 hover:bg-white/30 backdrop-blur-sm transition-all duration-300"
@@ -127,7 +127,7 @@
                 title="Toggle dark/light mode">
             <i class="fas fa-moon text-white text-lg" aria-hidden="true"></i>
         </button>
-        
+
         <!-- Search toggle -->
         <button id="search-toggle" type="button"
                 class="cursor-pointer p-2 rounded-full bg-white/20 hover:bg-white/30 backdrop-blur-sm transition-all duration-300"
@@ -144,6 +144,25 @@
                 aria-controls="settings-panel">
             <i class="fas fa-cog text-white text-lg" aria-hidden="true"></i>
         </button>
+    </div>
+
+    <div id="ambient-session-hud" class="ambient-session-hud hidden" role="status" aria-live="polite">
+        <svg class="ambient-session-ring" viewBox="0 0 120 120" aria-hidden="true">
+            <circle class="ambient-session-ring-bg" cx="60" cy="60" r="54"></circle>
+            <circle class="ambient-session-ring-progress" cx="60" cy="60" r="54"></circle>
+        </svg>
+        <div class="ambient-session-hud-body">
+            <p class="ambient-session-phase" id="ambient-session-phase">Idle</p>
+            <p class="ambient-session-time" id="ambient-session-remaining">00:00</p>
+        </div>
+        <div class="ambient-session-hud-actions">
+            <button id="ambient-hud-pause" type="button" class="ambient-session-hud-btn" aria-label="Pause session">
+                <i class="fas fa-pause"></i>
+            </button>
+            <button id="ambient-hud-stop" type="button" class="ambient-session-hud-btn" aria-label="Stop session">
+                <i class="fas fa-stop"></i>
+            </button>
+        </div>
     </div>
 
     <!-- Search Overlay -->
@@ -198,6 +217,42 @@
                     <option value="famous_quotes">Famous</option>
                   </select>
                 </div>
+
+                <section id="ambient-session-settings" class="mt-5 space-y-3" aria-label="Ambient session controls">
+                  <div class="flex items-center justify-between">
+                    <div>
+                      <h3 class="text-sm font-semibold text-gray-200">Ambient Sessions</h3>
+                      <p class="text-[11px] text-gray-400">Focus, breathe, or reset with guided cadence.</p>
+                    </div>
+                    <span id="ambient-session-streak" class="text-[11px] text-purple-300"></span>
+                  </div>
+                  <div class="space-y-2">
+                    <label for="ambient-session-type" class="text-xs text-gray-300">Session Type</label>
+                    <select id="ambient-session-type" class="w-full text-black p-1 rounded text-xs">
+                      <option value="focus">🎯 Focus</option>
+                      <option value="breathe">🌬️ Breathe</option>
+                      <option value="reset">🔁 Reset</option>
+                    </select>
+                  </div>
+                  <div class="space-y-2" aria-label="Session duration">
+                    <span class="text-xs text-gray-300">Duration</span>
+                    <div class="flex flex-wrap gap-2">
+                      <button type="button" class="ambient-duration-btn" data-minutes="5">5 min</button>
+                      <button type="button" class="ambient-duration-btn" data-minutes="15">15 min</button>
+                      <button type="button" class="ambient-duration-btn" data-minutes="25">25 min</button>
+                      <label class="flex items-center gap-1 text-xs text-gray-300">
+                        <span class="sr-only">Custom duration in minutes</span>
+                        <input id="ambient-session-custom" type="number" min="3" max="60" step="1" placeholder="Custom" class="w-20 text-center text-black rounded px-2 py-1" aria-label="Custom duration (minutes)">
+                        <span>min</span>
+                      </label>
+                    </div>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <button id="ambient-session-start" type="button" class="ambient-session-primary-btn flex-1">Start Session</button>
+                    <button id="ambient-session-pause" type="button" class="ambient-session-secondary-btn hidden" aria-pressed="false">Pause</button>
+                    <button id="ambient-session-stop" type="button" class="ambient-session-secondary-btn hidden">Stop</button>
+                  </div>
+                </section>
             </div>
 
             <!-- Appearance Tab -->
@@ -354,6 +409,24 @@
                         </div>
                     </div>
                 </details>
+
+                <details class="settings-accordion">
+                    <summary class="settings-accordion-header">🔗 Share &amp; Import</summary>
+                    <div class="settings-accordion-content space-y-3">
+                        <p class="text-[11px] text-gray-400">Share your vibe or load a preset from a friend.</p>
+                        <button id="preset-copy-btn" type="button" class="w-full ambient-session-primary-btn">Copy Shareable Preset</button>
+                        <button id="preset-import-btn" type="button" class="w-full ambient-session-secondary-btn" aria-expanded="false" aria-controls="preset-import-inline">Import from Link…</button>
+                        <form id="preset-import-inline" class="hidden space-y-2" autocomplete="off">
+                            <label for="preset-import-input" class="text-xs text-gray-300">Paste a shareable preset URL</label>
+                            <input id="preset-import-input" type="url" class="w-full text-black rounded px-2 py-1" placeholder="https://…#vibe=..." aria-describedby="preset-import-help">
+                            <p id="preset-import-help" class="text-[11px] text-gray-400">We’ll preview before applying anything.</p>
+                            <div class="flex items-center gap-2">
+                                <button type="submit" class="ambient-session-primary-btn flex-1">Preview</button>
+                                <button type="button" id="preset-import-cancel" class="ambient-session-secondary-btn">Cancel</button>
+                            </div>
+                        </form>
+                    </div>
+                </details>
             </div>
 
             <!-- Audio Tab -->
@@ -496,6 +569,13 @@
                             <span class="text-sm">New Vibe</span>
                         </button>
 
+                        <button id="ambient-session-quick-btn" type="button"
+                                class="ambient-session-quick-btn focus-chrome"
+                                aria-label="Start ambient session with last settings">
+                            <i class="fas fa-seedling" aria-hidden="true"></i>
+                            <span class="text-sm">Start Session</span>
+                        </button>
+
                         <div class="flex items-center dynamic-text-secondary text-sm space-x-3" 
                              aria-label="Auto-generation timer">
                             <button id="timer-toggle-btn" type="button"
@@ -557,6 +637,28 @@
                     class="mt-4 w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 transition-colors">
                 Close
             </button>
+        </div>
+    </div>
+
+    <div id="ambient-breathe-overlay" class="ambient-breathe-overlay hidden" aria-hidden="true">
+        <div class="ambient-breathe-ring">
+            <span id="ambient-breathe-label">Inhale</span>
+        </div>
+    </div>
+
+    <div id="preset-import-drawer" class="preset-import-drawer hidden" role="dialog" aria-modal="true" aria-labelledby="preset-import-title">
+        <div class="preset-import-card">
+            <div class="preset-import-header">
+                <h2 id="preset-import-title">Apply shared preset?</h2>
+                <button type="button" id="preset-import-close" class="preset-import-close" aria-label="Dismiss preset preview">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+            <div class="preset-import-preview" id="preset-import-preview" aria-live="polite"></div>
+            <div class="preset-import-actions">
+                <button type="button" id="preset-import-apply" class="ambient-session-primary-btn flex-1">Apply</button>
+                <button type="button" id="preset-import-ignore" class="ambient-session-secondary-btn flex-1">Ignore</button>
+            </div>
         </div>
     </div>
 
@@ -648,6 +750,8 @@
       }
     </script>
     
+    <script defer src="js/modules/ambientSessions.js"></script>
+    <script defer src="js/modules/presetLinks.js"></script>
     <script data-main defer src="js/main.js"></script>
 
     <!-- Fallback for browsers without script support -->

--- a/js/main.js
+++ b/js/main.js
@@ -646,6 +646,11 @@ const VibeMe = {
         this.updateStats && this.updateStats();
 
         console.log('✅ VibeMe Enhanced loaded successfully!');
+        try {
+            document.dispatchEvent(new CustomEvent('vibeme:ready', { detail: { vibeMe: this } }));
+        } catch (err) {
+            console.warn('[ambient] unable to dispatch ready event', err);
+        }
     },
 
     // ===== CORE FUNCTIONALITY =====
@@ -2441,6 +2446,12 @@ const VibeMe = {
             case 't':
             case 'T':
                 this.toggleTimer();
+                break;
+            case 's':
+            case 'S':
+                if (window.AmbientSessions && typeof window.AmbientSessions.toggleQuickStart === 'function') {
+                    window.AmbientSessions.toggleQuickStart();
+                }
                 break;
         }
     },

--- a/js/modules/ambientSessions.js
+++ b/js/modules/ambientSessions.js
@@ -1,0 +1,768 @@
+(function () {
+  const STORAGE_KEY = 'ambient:lastSession';
+  const HISTORY_KEY = 'ambient:sessionHistory';
+  const CIRCUMFERENCE = 2 * Math.PI * 54;
+  const DEFAULT_DURATION = 15;
+  const MIN_DURATION = 3;
+  const MAX_DURATION = 90;
+  const BREATHE_STEPS = [
+    { name: 'inhale', label: 'Inhale', duration: 4000 },
+    { name: 'hold', label: 'Hold', duration: 4000 },
+    { name: 'exhale', label: 'Exhale', duration: 6000 }
+  ];
+  const PROFILES = {
+    focus: {
+      quoteIntervalMs: 90_000,
+      speechOn: true,
+      speechSpeed: 0.9,
+      matrixDensity: 1.25,
+      matrixDensityReduced: 0.95,
+      animInterval: 620,
+      animIntervalReduced: 780,
+      chime: false
+    },
+    breathe: {
+      quoteIntervalMs: 0,
+      speechOn: false,
+      speechSpeed: 0.85,
+      matrixDensity: 0.85,
+      matrixDensityReduced: 0.7,
+      animInterval: 880,
+      animIntervalReduced: 980,
+      chime: true
+    },
+    reset: {
+      quoteIntervalMs: 30_000,
+      speechOn: true,
+      speechSpeed: 1.05,
+      matrixDensity: 1.55,
+      matrixDensityReduced: 1.1,
+      animInterval: 480,
+      animIntervalReduced: 560,
+      chime: false
+    }
+  };
+
+  const state = {
+    running: false,
+    paused: false,
+    type: 'focus',
+    phase: 'idle',
+    phaseIndex: 0,
+    phaseStart: 0,
+    phaseEnds: 0,
+    totalMs: 0,
+    remainingMs: 0,
+    endsAt: 0,
+    durations: { windIn: 0, active: 0, windDown: 0 },
+    lastPhaseIntensity: null,
+    pauseRemaining: 0,
+    pausePhaseRemaining: 0
+  };
+
+  const timers = {
+    tick: 0,
+    cadence: 0,
+    breathe: 0
+  };
+
+  const ui = {
+    typeSelect: null,
+    durationButtons: [],
+    customInput: null,
+    startBtn: null,
+    pauseBtn: null,
+    stopBtn: null,
+    quickBtn: null,
+    hud: null,
+    hudPhase: null,
+    hudRemaining: null,
+    hudPause: null,
+    hudStop: null,
+    ring: null,
+    streakLabel: null,
+    breatheOverlay: null,
+    breatheLabel: null
+  };
+
+  let vibe = null;
+  let baseline = null;
+  let lastApplied = { density: null, interval: null };
+  let lastSelection = { type: 'focus', minutes: DEFAULT_DURATION };
+  let reduceMotion = false;
+  let initDone = false;
+
+  const AmbientSessions = {
+    initAmbientSessions,
+    startSession,
+    pauseSession,
+    stopSession,
+    getSessionState,
+    toggleQuickStart
+  };
+
+  function initAmbientSessions() {
+    if (initDone) return;
+    initDone = true;
+
+    reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduceMotion) {
+      document.body.classList.add('ambient-reduced');
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      cacheElements();
+      attachUIHandlers();
+      hydrateFromStorage();
+      updateUIState();
+    });
+
+    document.addEventListener('vibeme:ready', (event) => {
+      const instance = event?.detail?.vibeMe || window.VibeMe;
+      if (instance) {
+        vibe = instance;
+      }
+    });
+
+    if (window.VibeMe) {
+      vibe = window.VibeMe;
+    }
+  }
+
+  function cacheElements() {
+    ui.typeSelect = document.getElementById('ambient-session-type');
+    ui.durationButtons = Array.from(document.querySelectorAll('.ambient-duration-btn'));
+    ui.customInput = document.getElementById('ambient-session-custom');
+    ui.startBtn = document.getElementById('ambient-session-start');
+    ui.pauseBtn = document.getElementById('ambient-session-pause');
+    ui.stopBtn = document.getElementById('ambient-session-stop');
+    ui.quickBtn = document.getElementById('ambient-session-quick-btn');
+    ui.hud = document.getElementById('ambient-session-hud');
+    ui.hudPhase = document.getElementById('ambient-session-phase');
+    ui.hudRemaining = document.getElementById('ambient-session-remaining');
+    ui.hudPause = document.getElementById('ambient-hud-pause');
+    ui.hudStop = document.getElementById('ambient-hud-stop');
+    ui.ring = document.querySelector('.ambient-session-ring-progress');
+    ui.streakLabel = document.getElementById('ambient-session-streak');
+    ui.breatheOverlay = document.getElementById('ambient-breathe-overlay');
+    ui.breatheLabel = document.getElementById('ambient-breathe-label');
+  }
+
+  function attachUIHandlers() {
+    if (ui.typeSelect) {
+      ui.typeSelect.addEventListener('change', (e) => {
+        lastSelection.type = sanitizeType(e.target.value);
+        persistSelection();
+      });
+    }
+
+    ui.durationButtons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const value = Number(btn.getAttribute('data-minutes'));
+        if (!Number.isFinite(value)) return;
+        lastSelection.minutes = clamp(value, MIN_DURATION, MAX_DURATION);
+        markActiveDuration(btn);
+        if (ui.customInput) {
+          ui.customInput.value = '';
+        }
+        persistSelection();
+      });
+    });
+
+    if (ui.customInput) {
+      ui.customInput.addEventListener('input', (event) => {
+        const value = Number(event.target.value);
+        if (!Number.isFinite(value)) return;
+        lastSelection.minutes = clamp(value, MIN_DURATION, MAX_DURATION);
+        clearDurationHighlights();
+        persistSelection();
+      });
+    }
+
+    if (ui.startBtn) {
+      ui.startBtn.addEventListener('click', () => {
+        if (state.running && state.paused) {
+          resumeSession();
+        } else {
+          startSession({ type: lastSelection.type, minutes: lastSelection.minutes });
+        }
+      });
+    }
+
+    if (ui.pauseBtn) {
+      ui.pauseBtn.addEventListener('click', () => {
+        if (!state.running) return;
+        if (state.paused) {
+          resumeSession();
+        } else {
+          pauseSession();
+        }
+      });
+    }
+
+    if (ui.stopBtn) {
+      ui.stopBtn.addEventListener('click', () => stopSession());
+    }
+
+    if (ui.quickBtn) {
+      ui.quickBtn.addEventListener('click', () => toggleQuickStart());
+    }
+
+    if (ui.hudPause) {
+      ui.hudPause.addEventListener('click', () => {
+        if (state.paused) {
+          resumeSession();
+        } else {
+          pauseSession();
+        }
+      });
+    }
+
+    if (ui.hudStop) {
+      ui.hudStop.addEventListener('click', () => stopSession());
+    }
+  }
+
+  function hydrateFromStorage() {
+    try {
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
+      if (stored && stored.type) {
+        lastSelection.type = sanitizeType(stored.type);
+      }
+      if (stored && Number.isFinite(stored.minutes)) {
+        lastSelection.minutes = clamp(stored.minutes, MIN_DURATION, MAX_DURATION);
+      }
+    } catch (err) {
+      console.warn('[ambient] failed to parse stored session selection', err);
+    }
+
+    updateSelectionUI();
+    updateStreak();
+  }
+
+  function sanitizeType(type) {
+    return Object.prototype.hasOwnProperty.call(PROFILES, type) ? type : 'focus';
+  }
+
+  function updateSelectionUI() {
+    if (ui.typeSelect) {
+      ui.typeSelect.value = lastSelection.type;
+    }
+    if (ui.customInput) {
+      ui.customInput.value = '';
+    }
+    let matchedPreset = false;
+    ui.durationButtons.forEach((btn) => {
+      const value = Number(btn.getAttribute('data-minutes'));
+      if (value === lastSelection.minutes) {
+        matchedPreset = true;
+        markActiveDuration(btn);
+      }
+    });
+    if (!matchedPreset && ui.customInput) {
+      ui.customInput.value = lastSelection.minutes;
+      clearDurationHighlights();
+    }
+  }
+
+  function markActiveDuration(button) {
+    clearDurationHighlights();
+    button.classList.add('is-active');
+  }
+
+  function clearDurationHighlights() {
+    ui.durationButtons.forEach((btn) => btn.classList.remove('is-active'));
+  }
+
+  function persistSelection() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(lastSelection));
+    } catch (_) {}
+    updateSelectionUI();
+  }
+
+  function updateStreak() {
+    if (!ui.streakLabel) return;
+    let count = 0;
+    try {
+      count = Number(localStorage.getItem(HISTORY_KEY) || '0');
+    } catch (_) {}
+    if (count > 0) {
+      ui.streakLabel.textContent = `${count} session${count === 1 ? '' : 's'} completed`;
+    } else {
+      ui.streakLabel.textContent = '';
+    }
+  }
+
+  function startSession(options = {}) {
+    const requestedType = sanitizeType(options.type || lastSelection.type);
+    const requestedMinutes = clamp(Number(options.minutes) || lastSelection.minutes || DEFAULT_DURATION, MIN_DURATION, MAX_DURATION);
+
+    if (!vibe) {
+      vibe = window.VibeMe;
+    }
+
+    if (!vibe) {
+      console.warn('[ambient] VibeMe instance not ready; session postponed');
+      return;
+    }
+
+    if (state.running) {
+      stopSession({ silent: true });
+    }
+
+    lastSelection = { type: requestedType, minutes: requestedMinutes };
+    persistSelection();
+
+    captureBaseline();
+    prepareEnvironment();
+
+    const now = performance.now();
+    const totalMs = requestedMinutes * 60_000;
+    const durations = computePhaseDurations(totalMs);
+
+    state.running = true;
+    state.paused = false;
+    state.type = requestedType;
+    state.durations = durations;
+    state.totalMs = totalMs;
+    state.remainingMs = totalMs;
+    state.phaseIndex = 0;
+    state.phase = 'windIn';
+    state.phaseStart = now;
+    state.phaseEnds = now + durations.windIn;
+    state.endsAt = now + totalMs;
+    state.lastPhaseIntensity = null;
+
+    applyProfileSpeech();
+    updateBodyClasses();
+    showHud(true);
+    updateUIState();
+    scheduleCadence();
+    startTickLoop();
+    if (state.type === 'breathe') {
+      startBreathingLoop();
+    }
+
+    dispatch('sessionstart', { type: state.type, minutes: requestedMinutes });
+  }
+
+  function computePhaseDurations(totalMs) {
+    let windIn = clamp(totalMs * 0.1, 10_000, 20_000);
+    let windDown = clamp(totalMs * 0.12, 20_000, 30_000);
+    let active = totalMs - windIn - windDown;
+    if (active < 60_000) {
+      const deficit = 60_000 - active;
+      const reduceIn = Math.min(deficit / 2, Math.max(0, windIn - 8_000));
+      const reduceDown = Math.min(deficit - reduceIn, Math.max(0, windDown - 12_000));
+      windIn -= reduceIn;
+      windDown -= reduceDown;
+      active = Math.max(30_000, totalMs - windIn - windDown);
+    }
+    if (active <= 0) {
+      active = Math.max(20_000, totalMs * 0.6);
+      const remainder = totalMs - active;
+      windIn = remainder / 2;
+      windDown = remainder / 2;
+    }
+    return { windIn, active, windDown };
+  }
+
+  function captureBaseline() {
+    baseline = {
+      matrixDensity: vibe?.matrixConfig?.densityMultiplier,
+      matrixInterval: vibe?.matrixConfig?.updateInterval,
+      ttsEnabled: vibe?.settings?.tts?.enabled,
+      ttsRate: vibe?.settings?.tts?.rate,
+      timerWasRunning: vibe?.state?.timerInterval ? !vibe.state.isPaused : false,
+      countdownValue: vibe?.state?.countdown,
+      quoteTimer: vibe?.state?.timerInterval
+    };
+    if (vibe?.state) {
+      vibe.state.isPaused = true;
+      if (vibe.state.timerInterval) {
+        clearInterval(vibe.state.timerInterval);
+        vibe.state.timerInterval = null;
+      }
+    }
+  }
+
+  function prepareEnvironment() {
+    lastApplied = { density: vibe?.matrixConfig?.densityMultiplier ?? null, interval: vibe?.matrixConfig?.updateInterval ?? null };
+  }
+
+  function applyProfileSpeech() {
+    if (!vibe?.settings?.tts) return;
+    const profile = PROFILES[state.type];
+    if (!profile) return;
+
+    const enable = !!profile.speechOn;
+    if (typeof baseline.ttsEnabled === 'boolean') {
+      vibe.settings.tts.enabled = enable;
+      const checkbox = document.getElementById('tts-enable-checkbox');
+      if (checkbox) checkbox.checked = enable;
+    }
+
+    if (typeof profile.speechSpeed === 'number' && typeof baseline.ttsRate === 'number') {
+      const clamped = clamp(profile.speechSpeed, 0.7, 1.4);
+      vibe.settings.tts.rate = clamped;
+      const slider = document.getElementById('tts-rate');
+      const label = document.getElementById('tts-rate-value');
+      if (slider) slider.value = String(clamped);
+      if (label) label.textContent = `${clamped.toFixed(1)}x`;
+    }
+  }
+
+  function startTickLoop() {
+    cancelAnimationFrame(timers.tick);
+    const loop = () => {
+      if (!state.running) return;
+      if (!state.paused) {
+        const now = performance.now();
+        state.remainingMs = Math.max(0, state.endsAt - now);
+        if (now >= state.phaseEnds) {
+          advancePhase(now);
+        }
+        if (state.remainingMs <= 0) {
+          completeSession();
+          return;
+        }
+        updateEnvironment(now);
+      }
+      updateHud();
+      timers.tick = requestAnimationFrame(loop);
+    };
+    timers.tick = requestAnimationFrame(loop);
+  }
+
+  function scheduleCadence() {
+    clearTimeout(timers.cadence);
+    const profile = PROFILES[state.type];
+    if (!profile || state.paused) return;
+    if (!profile.quoteIntervalMs) return;
+
+    const phaseMultiplier = state.phase === 'windIn' ? 1.25 : state.phase === 'windDown' ? 1.4 : 1;
+    const nextDelay = profile.quoteIntervalMs * phaseMultiplier;
+    timers.cadence = setTimeout(() => {
+      if (!state.running || state.paused) return;
+      if (typeof vibe?.updateQuote === 'function') {
+        vibe.updateQuote();
+      }
+      scheduleCadence();
+    }, nextDelay);
+  }
+
+  function startBreathingLoop() {
+    clearTimeout(timers.breathe);
+    if (!state.running || state.type !== 'breathe') return;
+
+    let index = 0;
+    const loop = () => {
+      if (!state.running || state.type !== 'breathe' || state.paused) return;
+      const step = BREATHE_STEPS[index];
+      applyBreatheStep(step);
+      index = (index + 1) % BREATHE_STEPS.length;
+      timers.breathe = setTimeout(loop, step.duration);
+    };
+    loop();
+  }
+
+  function applyBreatheStep(step) {
+    if (!step) return;
+    if (ui.breatheLabel) {
+      ui.breatheLabel.textContent = step.label;
+    }
+    document.body.dataset.breathePhase = step.name;
+    const profile = PROFILES[state.type];
+    if (profile?.chime && typeof vibe?.playSound === 'function') {
+      try {
+        vibe.playSound('success');
+      } catch (_) {}
+    }
+  }
+
+  function updateEnvironment(now) {
+    const profile = PROFILES[state.type];
+    if (!profile || !vibe?.matrixConfig) return;
+
+    const phaseDuration = state.durations[state.phase];
+    const elapsed = now - state.phaseStart;
+    let intensity = 1;
+    if (state.phase === 'windIn') {
+      intensity = clamp(elapsed / Math.max(1, phaseDuration), 0, 1);
+    } else if (state.phase === 'windDown') {
+      intensity = 1 - clamp(elapsed / Math.max(1, phaseDuration), 0, 1);
+    }
+
+    if (state.lastPhaseIntensity === intensity) return;
+    state.lastPhaseIntensity = intensity;
+
+    const targetDensity = reduceMotion ? profile.matrixDensityReduced ?? profile.matrixDensity : profile.matrixDensity;
+    const targetInterval = reduceMotion ? profile.animIntervalReduced ?? profile.animInterval : profile.animInterval;
+
+    if (typeof targetDensity === 'number') {
+      const base = typeof baseline.matrixDensity === 'number' ? baseline.matrixDensity : vibe.matrixConfig.densityMultiplier || 1.2;
+      const applied = lerp(base, targetDensity, intensity);
+      if (Math.abs((vibe.matrixConfig.densityMultiplier || 0) - applied) > 0.05) {
+        vibe.matrixConfig.densityMultiplier = applied;
+        if (typeof vibe.handleMatrixResize === 'function') {
+          vibe.handleMatrixResize();
+        }
+      }
+    }
+
+    if (typeof targetInterval === 'number') {
+      const baseInterval = typeof baseline.matrixInterval === 'number' ? baseline.matrixInterval : vibe.matrixConfig.updateInterval || 600;
+      const appliedInterval = lerp(baseInterval, targetInterval, intensity);
+      if (Math.abs((vibe.matrixConfig.updateInterval || 0) - appliedInterval) > 5) {
+        vibe.matrixConfig.updateInterval = appliedInterval;
+        if (typeof vibe.startMatrixUpdates === 'function') {
+          vibe.startMatrixUpdates();
+        }
+      }
+    }
+  }
+
+  function advancePhase(now) {
+    const order = ['windIn', 'active', 'windDown'];
+    state.phaseIndex = Math.min(order.length - 1, state.phaseIndex + 1);
+    state.phase = order[state.phaseIndex];
+    state.phaseStart = now;
+    state.phaseEnds = now + state.durations[state.phase];
+    state.lastPhaseIntensity = null;
+    scheduleCadence();
+    if (state.type === 'breathe' && !state.paused) {
+      startBreathingLoop();
+    }
+    updateHud();
+    dispatch('phasechange', { phase: state.phase });
+  }
+
+  function updateHud() {
+    if (!ui.hudPhase || !ui.hudRemaining || !ui.ring) return;
+    if (!state.running) {
+      ui.hudPhase.textContent = 'Idle';
+      ui.hudRemaining.textContent = '00:00';
+      ui.ring.style.strokeDashoffset = String(CIRCUMFERENCE);
+      return;
+    }
+
+    const phaseLabel = state.paused ? 'Paused' : phaseName(state.phase);
+    ui.hudPhase.textContent = phaseLabel;
+
+    const remaining = Math.max(0, state.remainingMs);
+    const minutes = Math.floor(remaining / 60_000);
+    const seconds = Math.floor((remaining % 60_000) / 1000);
+    ui.hudRemaining.textContent = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+
+    const progress = 1 - remaining / Math.max(1, state.totalMs);
+    const offset = CIRCUMFERENCE * (1 - clamp(progress, 0, 1));
+    ui.ring.style.strokeDashoffset = String(offset);
+
+    const pauseLabel = state.paused ? 'Resume' : 'Pause';
+    if (ui.pauseBtn) {
+      ui.pauseBtn.textContent = pauseLabel;
+      ui.pauseBtn.classList.remove('hidden');
+      ui.pauseBtn.setAttribute('aria-pressed', state.paused ? 'true' : 'false');
+    }
+    if (ui.hudPause) {
+      ui.hudPause.innerHTML = state.paused ? '<i class="fas fa-play"></i>' : '<i class="fas fa-pause"></i>';
+    }
+    if (ui.stopBtn) {
+      ui.stopBtn.classList.remove('hidden');
+    }
+  }
+
+  function phaseName(phase) {
+    switch (phase) {
+      case 'windIn':
+        return 'Wind In';
+      case 'active':
+        return 'Active';
+      case 'windDown':
+        return 'Wind Down';
+      default:
+        return 'Session';
+    }
+  }
+
+  function pauseSession() {
+    if (!state.running || state.paused) return;
+    state.paused = true;
+    const now = performance.now();
+    state.pauseRemaining = state.endsAt - now;
+    state.pausePhaseRemaining = state.phaseEnds - now;
+    clearTimeout(timers.cadence);
+    clearTimeout(timers.breathe);
+    updateHud();
+    updateUIState();
+    dispatch('sessionpause', { type: state.type });
+  }
+
+  function resumeSession() {
+    if (!state.running || !state.paused) return;
+    const now = performance.now();
+    state.paused = false;
+    state.endsAt = now + state.pauseRemaining;
+    state.phaseEnds = now + state.pausePhaseRemaining;
+    scheduleCadence();
+    if (state.type === 'breathe') {
+      startBreathingLoop();
+    }
+    updateHud();
+    updateUIState();
+    dispatch('sessionresume', { type: state.type });
+  }
+
+  function stopSession(options = {}) {
+    if (!state.running) return;
+    clearTimeout(timers.cadence);
+    clearTimeout(timers.breathe);
+    cancelAnimationFrame(timers.tick);
+
+    restoreBaseline();
+    state.running = false;
+    state.paused = false;
+    state.phase = 'idle';
+    state.phaseIndex = 0;
+    state.remainingMs = 0;
+    state.lastPhaseIntensity = null;
+
+    updateBodyClasses();
+    showHud(false);
+    updateHud();
+    updateUIState();
+
+    if (options.completed) {
+      incrementHistory();
+    }
+
+    dispatch('sessionstop', { type: state.type, completed: !!options.completed });
+  }
+
+  function restoreBaseline() {
+    if (!baseline || !vibe) return;
+    if (typeof baseline.matrixDensity === 'number') {
+      vibe.matrixConfig.densityMultiplier = baseline.matrixDensity;
+      if (typeof vibe.handleMatrixResize === 'function') {
+        vibe.handleMatrixResize();
+      }
+    }
+    if (typeof baseline.matrixInterval === 'number') {
+      vibe.matrixConfig.updateInterval = baseline.matrixInterval;
+      if (typeof vibe.startMatrixUpdates === 'function') {
+        vibe.startMatrixUpdates();
+      }
+    }
+    if (typeof baseline.ttsEnabled === 'boolean' && vibe?.settings?.tts) {
+      vibe.settings.tts.enabled = baseline.ttsEnabled;
+      const checkbox = document.getElementById('tts-enable-checkbox');
+      if (checkbox) checkbox.checked = baseline.ttsEnabled;
+    }
+    if (typeof baseline.ttsRate === 'number' && vibe?.settings?.tts) {
+      vibe.settings.tts.rate = baseline.ttsRate;
+      const slider = document.getElementById('tts-rate');
+      const label = document.getElementById('tts-rate-value');
+      if (slider) slider.value = String(baseline.ttsRate);
+      if (label) label.textContent = `${baseline.ttsRate.toFixed(1)}x`;
+    }
+    if (baseline.timerWasRunning && typeof vibe.startTimer === 'function') {
+      vibe.state.isPaused = false;
+      vibe.startTimer();
+    }
+    if (ui.breatheOverlay) {
+      document.body.removeAttribute('data-breathe-phase');
+    }
+  }
+
+  function completeSession() {
+    stopSession({ completed: true });
+    showToast('Session complete 🎉', 'success', 2400);
+  }
+
+  function updateBodyClasses() {
+    document.body.classList.toggle('ambient-active', state.running);
+    document.body.classList.toggle('ambient-breathe', state.running && state.type === 'breathe');
+  }
+
+  function showHud(show) {
+    if (!ui.hud) return;
+    if (show) {
+      ui.hud.classList.remove('hidden');
+    } else {
+      ui.hud.classList.add('hidden');
+    }
+  }
+
+  function updateUIState() {
+    if (ui.startBtn) {
+      ui.startBtn.textContent = state.running && !state.paused ? 'Restart Session' : (state.paused ? 'Resume Session' : 'Start Session');
+    }
+    if (ui.pauseBtn) {
+      ui.pauseBtn.classList.toggle('hidden', !state.running);
+      ui.pauseBtn.textContent = state.paused ? 'Resume' : 'Pause';
+    }
+    if (ui.stopBtn) {
+      ui.stopBtn.classList.toggle('hidden', !state.running);
+    }
+    if (ui.quickBtn) {
+      const label = ui.quickBtn.querySelector('span');
+      if (label) {
+        label.textContent = state.running ? 'Stop Session' : 'Start Session';
+      }
+    }
+    updateStreak();
+  }
+
+  function incrementHistory() {
+    let count = 0;
+    try {
+      count = Number(localStorage.getItem(HISTORY_KEY) || '0');
+    } catch (_) {}
+    count += 1;
+    try {
+      localStorage.setItem(HISTORY_KEY, String(count));
+    } catch (_) {}
+    updateStreak();
+  }
+
+  function getSessionState() {
+    return {
+      running: state.running,
+      paused: state.paused,
+      type: state.type,
+      phase: state.phase,
+      remainingMs: state.remainingMs
+    };
+  }
+
+  function toggleQuickStart() {
+    if (state.running) {
+      stopSession();
+    } else {
+      startSession({ type: lastSelection.type, minutes: lastSelection.minutes });
+    }
+  }
+
+  function dispatch(name, detail) {
+    document.dispatchEvent(new CustomEvent(`ambient:${name}`, { detail }));
+  }
+
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  function lerp(a, b, t) {
+    return a + (b - a) * t;
+  }
+
+  function showToast(message, type, ms) {
+    if (typeof window.showToast === 'function') {
+      window.showToast(message, type, ms);
+    }
+  }
+
+  initAmbientSessions();
+
+  window.AmbientSessions = AmbientSessions;
+})();

--- a/js/modules/presetLinks.js
+++ b/js/modules/presetLinks.js
@@ -1,0 +1,519 @@
+(function () {
+  const KEY = 'vibe';
+  const PresetLinks = {
+    serializeCurrentPreset,
+    applyPresetObject,
+    parseAndOfferPresetFromURL
+  };
+
+  const ui = {
+    copyBtn: null,
+    importBtn: null,
+    importForm: null,
+    importInput: null,
+    importCancel: null,
+    drawer: null,
+    drawerPreview: null,
+    drawerApply: null,
+    drawerIgnore: null,
+    drawerClose: null
+  };
+
+  let pendingPreset = null;
+
+  document.addEventListener('DOMContentLoaded', () => {
+    cacheElements();
+    attachListeners();
+    parseAndOfferPresetFromURL();
+  });
+
+  window.PresetLinks = PresetLinks;
+
+  function cacheElements() {
+    ui.copyBtn = document.getElementById('preset-copy-btn');
+    ui.importBtn = document.getElementById('preset-import-btn');
+    ui.importForm = document.getElementById('preset-import-inline');
+    ui.importInput = document.getElementById('preset-import-input');
+    ui.importCancel = document.getElementById('preset-import-cancel');
+    ui.drawer = document.getElementById('preset-import-drawer');
+    ui.drawerPreview = document.getElementById('preset-import-preview');
+    ui.drawerApply = document.getElementById('preset-import-apply');
+    ui.drawerIgnore = document.getElementById('preset-import-ignore');
+    ui.drawerClose = document.getElementById('preset-import-close');
+  }
+
+  function attachListeners() {
+    if (ui.copyBtn) {
+      ui.copyBtn.addEventListener('click', async () => {
+        try {
+          const url = serializeCurrentPreset();
+          await navigator.clipboard.writeText(url);
+          toast('Preset copied ✅', 'success');
+        } catch (err) {
+          fallbackCopy();
+        }
+      });
+    }
+
+    if (ui.importBtn) {
+      ui.importBtn.addEventListener('click', () => {
+        if (!ui.importForm) return;
+        const isHidden = ui.importForm.classList.contains('hidden');
+        ui.importBtn.setAttribute('aria-expanded', String(isHidden));
+        ui.importForm.classList.toggle('hidden', !isHidden);
+        if (isHidden && ui.importInput) {
+          setTimeout(() => ui.importInput.focus(), 0);
+        }
+      });
+    }
+
+    if (ui.importForm) {
+      ui.importForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        if (!ui.importInput) return;
+        handlePresetString(ui.importInput.value);
+      });
+    }
+
+    if (ui.importCancel) {
+      ui.importCancel.addEventListener('click', () => {
+        if (!ui.importForm) return;
+        ui.importForm.classList.add('hidden');
+        ui.importBtn?.setAttribute('aria-expanded', 'false');
+        if (ui.importInput) ui.importInput.value = '';
+      });
+    }
+
+    if (ui.drawerApply) {
+      ui.drawerApply.addEventListener('click', () => {
+        if (!pendingPreset) return;
+        applyPresetObject(pendingPreset);
+        toast('Preset applied 🎉', 'success');
+        closeDrawer();
+      });
+    }
+
+    if (ui.drawerIgnore) {
+      ui.drawerIgnore.addEventListener('click', () => {
+        closeDrawer();
+      });
+    }
+
+    if (ui.drawerClose) {
+      ui.drawerClose.addEventListener('click', () => closeDrawer());
+    }
+  }
+
+  function fallbackCopy() {
+    try {
+      const url = serializeCurrentPreset();
+      const textarea = document.createElement('textarea');
+      textarea.value = url;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'absolute';
+      textarea.style.left = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+      toast('Preset copied ✅', 'success');
+    } catch (err) {
+      toast('Unable to copy preset', 'error');
+    }
+  }
+
+  function serializeCurrentPreset() {
+    const data = collectCurrentPreset();
+    const json = JSON.stringify(data);
+    const encoded = base64UrlEncode(json);
+    const origin = `${location.origin}${location.pathname}`;
+    return `${origin}#${KEY}=${encoded}`;
+  }
+
+  function collectCurrentPreset() {
+    const payload = {};
+    const vibe = window.VibeMe || {};
+
+    const themePreset = safeGetLocalStorage('vibeme-theme-preset');
+    if (themePreset && themePreset !== 'auto') {
+      payload.themePreset = themePreset;
+    }
+
+    const colorPrefs = parseJSON(safeGetLocalStorage('vibeme-color-preferences')) || {};
+    if (colorPrefs.harmonyType && colorPrefs.harmonyType !== 'auto') {
+      payload.colorHarmony = colorPrefs.harmonyType;
+    }
+    if (typeof colorPrefs.vibrancy !== 'undefined') {
+      payload.vibrancy = Number(colorPrefs.vibrancy);
+    }
+    if (typeof colorPrefs.warmth !== 'undefined') {
+      payload.warmth = Number(colorPrefs.warmth);
+    }
+    if (typeof colorPrefs.accessibility === 'boolean') {
+      payload.a11yMode = colorPrefs.accessibility;
+    }
+
+    const matrixPrefs = parseJSON(safeGetLocalStorage('vibeme-matrix-preferences')) || {};
+    if (typeof matrixPrefs.opacity !== 'undefined') {
+      payload.matrixVisibility = Number(matrixPrefs.opacity);
+    }
+    if (typeof matrixPrefs.density !== 'undefined') {
+      payload.streamDensity = Number(matrixPrefs.density);
+    }
+    if (typeof matrixPrefs.speed !== 'undefined') {
+      payload.animSpeed = Number(matrixPrefs.speed);
+    }
+    if (typeof matrixPrefs.highContrast === 'boolean') {
+      payload.highContrast = matrixPrefs.highContrast;
+    }
+    if (matrixPrefs.blendMode && matrixPrefs.blendMode !== 'auto') {
+      payload.blendMode = matrixPrefs.blendMode;
+    }
+    if (typeof matrixPrefs.maxFps !== 'undefined') {
+      payload.fpsCap = Number(matrixPrefs.maxFps);
+    }
+
+    const matrixPreset = safeGetLocalStorage('vibeme-matrix-preset');
+    if (matrixPreset && matrixPreset !== 'auto') {
+      payload.matrixPreset = matrixPreset;
+    }
+
+    if (vibe.matrixConfig?.renderMode) {
+      payload.engine = vibe.matrixConfig.renderMode;
+    }
+    if (vibe.matrixConfig?.densityMultiplier && typeof payload.streamDensity === 'undefined') {
+      payload.streamDensity = Number(vibe.matrixConfig.densityMultiplier);
+    }
+
+    if (vibe.matrixConfig?.updateInterval && typeof payload.animSpeed === 'undefined') {
+      const speed = 500 / vibe.matrixConfig.updateInterval;
+      if (Number.isFinite(speed)) payload.animSpeed = Number(speed.toFixed(2));
+    }
+
+    if (vibe.matrixConfig?.canvasConfig?.maxFPS && typeof payload.fpsCap === 'undefined') {
+      payload.fpsCap = Number(vibe.matrixConfig.canvasConfig.maxFPS);
+    }
+
+    const category = vibe.state?.categoryFilter;
+    if (category && category !== 'all') {
+      payload.quoteCategory = category;
+    }
+
+    const ttsSettings = vibe.settings?.tts;
+    if (ttsSettings) {
+      payload.speechOn = !!ttsSettings.enabled;
+      if (typeof ttsSettings.rate === 'number') {
+        payload.speechSpeed = Number(ttsSettings.rate);
+      }
+      if (ttsSettings.voiceURI) {
+        payload.voice = ttsSettings.voiceURI;
+      }
+    }
+
+    if (vibe.settings?.tts?.voiceURI) {
+      payload.voice = vibe.settings.tts.voiceURI;
+    }
+
+    return payload;
+  }
+
+  function parseAndOfferPresetFromURL() {
+    const token = extractToken(location.hash);
+    if (!token) return;
+    const obj = decodeToken(token);
+    const valid = validatePreset(obj);
+    if (!valid) {
+      toast('Invalid preset link', 'error');
+      clearHash();
+      return;
+    }
+    openDrawer(valid);
+    clearHash();
+  }
+
+  function handlePresetString(input) {
+    const token = extractToken(input);
+    if (!token) {
+      toast('No preset token found', 'error');
+      return;
+    }
+    const obj = decodeToken(token);
+    const valid = validatePreset(obj);
+    if (!valid) {
+      toast('Invalid preset link', 'error');
+      return;
+    }
+    openDrawer(valid);
+  }
+
+  function extractToken(str) {
+    if (!str) return null;
+    const match = str.match(new RegExp(`${KEY}=([^&]+)`));
+    if (match && match[1]) return match[1];
+    if (/^[A-Za-z0-9_-]+$/.test(str)) return str;
+    const parts = str.split('#');
+    if (parts.length > 1) {
+      return extractToken(parts[1]);
+    }
+    const queryMatch = str.match(/vibe=([^&]+)/);
+    return queryMatch ? queryMatch[1] : null;
+  }
+
+  function decodeToken(token) {
+    try {
+      const padded = padBase64(token.replace(/-/g, '+').replace(/_/g, '/'));
+      const decoded = atob(padded);
+      const bytes = Uint8Array.from(decoded, (c) => c.charCodeAt(0));
+      const json = new TextDecoder().decode(bytes);
+      return JSON.parse(json);
+    } catch (err) {
+      console.warn('[preset] decode failed', err);
+      return null;
+    }
+  }
+
+  function validatePreset(obj) {
+    if (!obj || typeof obj !== 'object') return null;
+    const clean = {};
+
+    if (typeof obj.themePreset === 'string') clean.themePreset = obj.themePreset;
+    if (typeof obj.matrixPreset === 'string') clean.matrixPreset = obj.matrixPreset;
+    if (typeof obj.colorHarmony === 'string') clean.colorHarmony = obj.colorHarmony;
+    if (typeof obj.vibrancy === 'number') clean.vibrancy = clamp(obj.vibrancy, 0, 100);
+    if (typeof obj.warmth === 'number') clean.warmth = clamp(obj.warmth, 0, 100);
+    if (typeof obj.a11yMode === 'boolean') clean.a11yMode = obj.a11yMode;
+
+    if (typeof obj.matrixVisibility === 'number') clean.matrixVisibility = clamp(obj.matrixVisibility, 0, 100);
+    if (typeof obj.streamDensity === 'number') clean.streamDensity = clamp(obj.streamDensity, 0.5, 3);
+    if (typeof obj.animSpeed === 'number') clean.animSpeed = clamp(obj.animSpeed, 0.5, 2.5);
+    if (typeof obj.highContrast === 'boolean') clean.highContrast = obj.highContrast;
+    if (typeof obj.blendMode === 'string') clean.blendMode = obj.blendMode;
+    if (typeof obj.fpsCap === 'number') clean.fpsCap = clamp(Math.round(obj.fpsCap), 30, 240);
+    if (typeof obj.engine === 'string') clean.engine = obj.engine;
+
+    if (typeof obj.quoteCategory === 'string') clean.quoteCategory = obj.quoteCategory;
+
+    if (typeof obj.speechOn === 'boolean') clean.speechOn = obj.speechOn;
+    if (typeof obj.speechSpeed === 'number') clean.speechSpeed = clamp(obj.speechSpeed, 0.6, 1.6);
+    if (typeof obj.voice === 'string') clean.voice = obj.voice;
+
+    return Object.keys(clean).length ? clean : {};
+  }
+
+  function applyPresetObject(obj) {
+    if (!obj) return;
+    const vibe = window.VibeMe;
+
+    if (obj.themePreset) {
+      localStorage.setItem('vibeme-theme-preset', obj.themePreset);
+      const select = document.getElementById('theme-preset');
+      if (select) {
+        select.value = obj.themePreset;
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    }
+
+    if (obj.matrixPreset) {
+      localStorage.setItem('vibeme-matrix-preset', obj.matrixPreset);
+      const select = document.getElementById('matrix-preset');
+      if (select) {
+        select.value = obj.matrixPreset;
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    }
+
+    if (obj.colorHarmony || typeof obj.vibrancy !== 'undefined' || typeof obj.warmth !== 'undefined' || typeof obj.a11yMode !== 'undefined') {
+      const prefs = parseJSON(safeGetLocalStorage('vibeme-color-preferences')) || {};
+      if (obj.colorHarmony) prefs.harmonyType = obj.colorHarmony;
+      if (typeof obj.vibrancy !== 'undefined') prefs.vibrancy = obj.vibrancy;
+      if (typeof obj.warmth !== 'undefined') prefs.warmth = obj.warmth;
+      if (typeof obj.a11yMode !== 'undefined') prefs.accessibility = obj.a11yMode;
+      localStorage.setItem('vibeme-color-preferences', JSON.stringify(prefs));
+      if (vibe?.applyRandomTheme) vibe.applyRandomTheme();
+      if (obj.colorHarmony) {
+        const select = document.getElementById('harmony-type');
+        if (select) select.value = obj.colorHarmony;
+      }
+      if (typeof obj.vibrancy !== 'undefined') {
+        const slider = document.getElementById('vibrancy-slider');
+        const label = document.getElementById('vibrancy-value');
+        if (slider) slider.value = obj.vibrancy;
+        if (label) label.textContent = `${Math.round(obj.vibrancy)}%`;
+      }
+      if (typeof obj.warmth !== 'undefined') {
+        const slider = document.getElementById('warmth-slider');
+        const label = document.getElementById('warmth-value');
+        if (slider) slider.value = obj.warmth;
+        if (label) label.textContent = `${Math.round(obj.warmth)}%`;
+      }
+      if (typeof obj.a11yMode !== 'undefined') {
+        const checkbox = document.getElementById('accessibility-mode');
+        if (checkbox) checkbox.checked = obj.a11yMode;
+      }
+    }
+
+    if (typeof obj.matrixVisibility !== 'undefined' && vibe?.updateMatrixSetting) {
+      vibe.updateMatrixSetting('opacity', obj.matrixVisibility);
+    }
+    if (typeof obj.streamDensity !== 'undefined' && vibe?.updateMatrixSetting) {
+      vibe.updateMatrixSetting('density', obj.streamDensity);
+    }
+    if (typeof obj.animSpeed !== 'undefined' && vibe?.updateMatrixSetting) {
+      vibe.updateMatrixSetting('speed', obj.animSpeed);
+    }
+    if (typeof obj.highContrast !== 'undefined' && vibe?.updateMatrixSetting) {
+      vibe.updateMatrixSetting('highContrast', obj.highContrast);
+    }
+    if (obj.blendMode && vibe?.updateMatrixSetting) {
+      vibe.updateMatrixSetting('blendMode', obj.blendMode);
+      const select = document.getElementById('matrix-blend-mode');
+      if (select) select.value = obj.blendMode;
+    }
+    if (typeof obj.fpsCap !== 'undefined' && vibe?.updateMatrixSetting) {
+      vibe.updateMatrixSetting('maxFps', obj.fpsCap);
+      const slider = document.getElementById('canvas-max-fps');
+      const label = document.getElementById('canvas-max-fps-value');
+      if (slider) slider.value = obj.fpsCap;
+      if (label) label.textContent = obj.fpsCap;
+    }
+
+    if (obj.engine && vibe?.updateMatrixRenderMode) {
+      vibe.updateMatrixRenderMode(obj.engine);
+      const select = document.getElementById('matrix-render-mode');
+      if (select) select.value = obj.engine;
+    }
+
+    if (obj.quoteCategory) {
+      const select = document.getElementById('category-filter');
+      if (select) {
+        select.value = obj.quoteCategory;
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    }
+
+    if (typeof obj.speechOn !== 'undefined' && vibe?.settings?.tts) {
+      vibe.settings.tts.enabled = obj.speechOn;
+      const checkbox = document.getElementById('tts-enable-checkbox');
+      if (checkbox) checkbox.checked = obj.speechOn;
+    }
+    if (typeof obj.speechSpeed !== 'undefined' && vibe?.settings?.tts) {
+      vibe.settings.tts.rate = obj.speechSpeed;
+      const slider = document.getElementById('tts-rate');
+      const label = document.getElementById('tts-rate-value');
+      if (slider) slider.value = obj.speechSpeed;
+      if (label) label.textContent = `${obj.speechSpeed.toFixed(1)}x`;
+    }
+    if (obj.voice && vibe?.tts?.voices?.length) {
+      const match = vibe.tts.voices.find((voice) => voice.voiceURI === obj.voice);
+      if (match) {
+        vibe.settings.tts.voiceURI = obj.voice;
+        const select = document.getElementById('tts-voice');
+        if (select) select.value = obj.voice;
+      }
+    }
+  }
+
+  function openDrawer(presetObj) {
+    pendingPreset = presetObj;
+    if (!ui.drawer || !ui.drawerPreview) return;
+    if (ui.importForm) ui.importForm.classList.add('hidden');
+    if (ui.importBtn) ui.importBtn.setAttribute('aria-expanded', 'false');
+    ui.drawerPreview.innerHTML = renderPreview(presetObj);
+    ui.drawer.classList.remove('hidden');
+    requestAnimationFrame(() => ui.drawer.classList.add('is-open'));
+  }
+
+  function closeDrawer() {
+    pendingPreset = null;
+    if (!ui.drawer) return;
+    ui.drawer.classList.remove('is-open');
+    setTimeout(() => ui.drawer?.classList.add('hidden'), 260);
+  }
+
+  function renderPreview(obj) {
+    const vibe = window.VibeMe || {};
+    const colors = pickPaletteColors(obj.themePreset, vibe);
+    const swatches = colors.map((color) => `<span class="preset-preview-swatch" style="background:${color}"></span>`).join('');
+
+    const voiceLabel = obj.voice
+      ? `Voice: ${obj.voice}`
+      : `Voice: ${typeof obj.speechOn === 'boolean' ? (obj.speechOn ? 'Default' : 'Off') : 'unchanged'}`;
+    const engineLabel = obj.engine ? `Engine: ${obj.engine}` : '';
+    const quoteLabel = obj.quoteCategory ? `Quotes: ${obj.quoteCategory}` : '';
+
+    return `
+      <div class="preset-preview-swatches">${swatches}</div>
+      <div class="preset-import-meta">
+        <span>${obj.themePreset ? `Theme: ${obj.themePreset}` : 'Theme: current'}</span>
+        ${obj.colorHarmony ? `<span>Harmony: ${obj.colorHarmony}</span>` : ''}
+        ${obj.matrixPreset ? `<span>Matrix preset: ${obj.matrixPreset}</span>` : ''}
+        ${engineLabel ? `<span>${engineLabel}</span>` : ''}
+        ${quoteLabel ? `<span>${quoteLabel}</span>` : ''}
+        <span>${voiceLabel}</span>
+      </div>
+    `;
+  }
+
+  function pickPaletteColors(presetName, vibe) {
+    const bank = vibe?.themes?.colorPalettes?.[presetName];
+    if (Array.isArray(bank) && bank.length) {
+      const palette = bank[0];
+      return [palette.color1, palette.color2, palette.color3].filter(Boolean);
+    }
+    const current = vibe?.currentTheme;
+    if (current) {
+      return [current.color1, current.color2, current.color3].filter(Boolean);
+    }
+    return ['#6366f1', '#8b5cf6', '#c4b5fd'];
+  }
+
+  function parseJSON(str) {
+    if (!str) return null;
+    try {
+      return JSON.parse(str);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function safeGetLocalStorage(key) {
+    try {
+      return localStorage.getItem(key);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function base64UrlEncode(str) {
+    const bytes = new TextEncoder().encode(str);
+    let binary = '';
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  }
+
+  function padBase64(str) {
+    const pad = str.length % 4;
+    if (!pad) return str;
+    return str + '='.repeat(4 - pad);
+  }
+
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  function toast(message, type) {
+    if (typeof window.showToast === 'function') {
+      window.showToast(message, type || 'info', 2400);
+    }
+  }
+
+  function clearHash() {
+    if (history.replaceState) {
+      history.replaceState(null, document.title, `${location.pathname}${location.search}`);
+    } else {
+      location.hash = '';
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- introduce an ambient session engine with HUD, breathing overlay, persistence, and keyboard shortcut integration
- add UI controls and styling for session management plus new share/import affordances
- implement preset serialization/import module that copies shareable URLs and applies validated presets with a preview drawer

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910cf415ae4832bbe36f606e2d94af0)